### PR TITLE
update docs for @WithMockKeycloakAuth

### DIFF
--- a/spring-security-oauth2-test-addons/README.MD
+++ b/spring-security-oauth2-test-addons/README.MD
@@ -101,19 +101,21 @@ public void test() {
 ### `@WithMockKeycloakAuth` sample usage
 
 You might customize about any claim in Keycloak access and ID tokens.
-As Keycloak `AccessToken` extends `IDToken` and annotation inheritance is not possible in Java, I used composition (reason for `idToken` property in `@WithAccessToken`).
 
 ```java
 	@Test
 	@WithMockKeycloakAuth(
 			authorities = { "USER", "AUTHORIZED_PERSONNEL" },
-			id = @IdTokenClaims(sub = "42"),
-			oidc = @OidcStandardClaims(
+			claims = @OpenIdClaims(
 					email = "ch4mp@c4-soft.com",
 					emailVerified = true,
 					nickName = "Tonton-Pirate",
-					preferredUsername = "ch4mpy"),
-			otherClaims = @ClaimSet(stringClaims = @StringClaim(name = "foo", value = "bar")))
+					preferredUsername = "ch4mpy", 
+					otherClaims = @Claims(
+						stringClaims = @StringClaim(name = "foo", value = "bar")
+					)
+				)
+	)
 	public void whenAuthenticatedWithKeycloakAuthenticationTokenThenCanGreet() throws Exception {
 		api.get("/greet")
 				.andExpect(status().isOk())

--- a/spring-security-oauth2-test-addons/src/main/java/com/c4_soft/springaddons/security/oauth2/test/annotations/keycloak/WithMockKeycloakAuth.java
+++ b/spring-security-oauth2-test-addons/src/main/java/com/c4_soft/springaddons/security/oauth2/test/annotations/keycloak/WithMockKeycloakAuth.java
@@ -50,13 +50,13 @@ import com.c4_soft.springaddons.security.oauth2.test.keycloak.KeycloakAuthentica
  * &#64;Test
  * &#64;WithMockKeycloakAuth(
 			authorities = { "USER", "AUTHORIZED_PERSONNEL" },
-			oidc = &#64;OidcStandardClaims(
+			claims = &#64;OpenIdClaims(
 					sub = "42",
 					email = "ch4mp@c4-soft.com",
 					emailVerified = true,
 					nickName = "Tonton-Pirate",
 					preferredUsername = "ch4mpy",
-					otherClaims = &#64;ClaimSet(stringClaims = &#64;StringClaim(name = "foo", value = "bar"))),
+					otherClaims = &#64;Claims(stringClaims = &#64;StringClaim(name = "foo", value = "bar"))),
 			)
  * public void test() {
  *     ...


### PR DESCRIPTION
I noticed these small issues when I was trying setting the claims, so I

- replaced `@OidcStandardClaims` with `@OpenIdClaims` in readme and javadoc 
- replaced `@ClaimSet` with `@Claims` in readme and javadoc 
- removed `@IdTokenClaims` from readme