### PR TITLE
implement keycloak in docker for tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ Thumbs.db
 application-secret.properties
 
 
+/samples/tutorials/infrastructure/keycloak/

--- a/README.MD
+++ b/README.MD
@@ -38,7 +38,7 @@ This repo contains thin wrappers around `spring-boot-starter-oauth2-resource-ser
 - [spring-addons-webmvc-introspecting-resource-server](https://github.com/ch4mpy/spring-addons/tree/master/webmvc/spring-addons-webmvc-introspecting-resource-server) to be used in servlet REST APIs secured with access token introspection
 - [spring-addons-webmvc-jwt-resource-server](https://github.com/ch4mpy/spring-addons/tree/master/webmvc/spring-addons-webmvc-jwt-resource-server) to be used in **servlet REST APIs secured with JWT decoders**
 
-This starters are designed to push auto-configuration one step further. In most cases, you should need 0 Java conf. An effort was made to make [tutorials](https://github.com/ch4mpy/spring-addons/tree/master/samples/tutorials), Javadoc and modules READMEs as informative as possible. Please refer there for more details.
+This starters are designed to push auto-configuration one step further. In most cases, you should need 0 Java conf. An effort was made to make [tutorials](https://github.com/ch4mpy/spring-addons/tree/master/samples/tutorials), Javadoc and modules READMEs as informative as possible. Please refer there for more details. Additionally refer to [module, dependency, class and other diagrams](https://sourcespy.com/github/ch4mpyspringaddons/) for a general overview of the repository.
 
 ## 3. <a name="start"/>Where to Start
 [Tutorials](https://github.com/ch4mpy/spring-addons/tree/master/samples/tutorials) which cover:

--- a/samples/tutorials/infrastructure/README.md
+++ b/samples/tutorials/infrastructure/README.md
@@ -1,0 +1,31 @@
+# Docker configuration for tutorials
+This directory contains a docker compose (V3) file that will start keycloak without installing it locally.
+
+## Prerequisites
+1. A recent version of docker that supports the new compose file format (V3)
+2. A self-signed SSL certificate.  See [this github reposiotry](https://github.com/ch4mpy/self-signed-certificate-generation) for tutorial on creating one for your development environment.
+
+## Changes you have to make locally
+1. Create a subdirectory `samples/tutorials/infrastructure/keycloak`
+2. Add the following files to this directory
+   1. The self-signed SSL certificate for your development environment re-named to `self_signed.crt`
+   2. The private key associated with the certificate for for your development environment re-named to `self_signed_key.pem`
+
+The files in this directory (`samples/tutorials/infrastructure/keycloak`) are needed to make keycloak work from docker compose.  However, they contain sensitive information that should never be committed to a repository.
+The project's `.gitignore` should contain the following line
+```
+/samples/tutorials/infrastructure/keycloak/
+```
+
+## Starting keycloak
+1. Open a terminal
+2. Change directory to `samples/tutorials/infrastructure`
+3. Enter the command `docker compose up --detach`
+4. Open a browser and navigate to the [running keycloak instance](https://localhost:8443/admin)
+5. Enter user `admin` with password `admin1`
+6. Continue configuring keycloak with the README.md in tutorial directory in the Prerequisites section
+
+## Stopping keycloak
+1. Open a terminal (or use the one already open)
+2. Change directory to `samples/tutorials/infrastructure`
+3. Enter the command `docker compose down`

--- a/samples/tutorials/infrastructure/compose.yaml
+++ b/samples/tutorials/infrastructure/compose.yaml
@@ -1,0 +1,44 @@
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:21.1.1
+    command: [ " start-dev" ]
+    secrets:
+      - source: server_crt
+        target: /etc/x509/https/tls.crt
+        uid: '103'
+        gid: '103'
+        mode: 0440
+      - source: server_key
+        target: /etc/x509/https/tls.key
+        uid: '103'
+        gid: '103'
+        mode: 0440
+    volumes:
+      - type: volume
+        source: keycloak-spring-addons
+        target: /opt/keycloak/data
+    ports:
+      - target: 8443 # Keycloak HTTPS port
+        published: 8443
+        protocol: tcp
+        mode: host
+      - target: 8080 # Keycloak HTTP port
+        published: 8442
+        protocol: tcp
+        mode: host
+    environment:
+      - KEYCLOAK_ADMIN=admin
+      - KEYCLOAK_ADMIN_PASSWORD=admin1
+      - KC_HTTPS_CERTIFICATE_FILE=/etc/x509/https/tls.crt
+      - KC_HTTPS_CERTIFICATE_KEY_FILE=/etc/x509/https/tls.key
+    container_name: spring-addons-keycloak
+
+volumes:
+  keycloak-spring-addons:
+    name: keycloak-spring-addons
+
+secrets:
+  server_crt:
+    file: keycloak/self_signed.crt
+  server_key:
+    file: keycloak/self_signed_key.pem


### PR DESCRIPTION
I try to leverage docker as much as possible to keep current versions of software and reduce the impact of locally installed development software.  This PR has the setup to use a dockerized Keycloak for the tutorials.  

Note this is my very first PR on any project so please give me any feedback to improve.
