### PR TITLE
Fix the possibility to override the logout request uri (end_session endpoint)

### DIFF
--- a/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/SpringAddonsOAuth2LogoutRequestUriBuilder.java
+++ b/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/SpringAddonsOAuth2LogoutRequestUriBuilder.java
@@ -30,7 +30,7 @@ public class SpringAddonsOAuth2LogoutRequestUriBuilder implements LogoutRequestU
     @Override
     public Optional<String> getLogoutRequestUri(ClientRegistration clientRegistration, String idToken, Optional<URI> postLogoutUri) {
         final var logoutProps = clientProperties.getLogoutProperties(clientRegistration.getRegistrationId());
-        if (logoutProps.map(OAuth2LogoutProperties::isEnabled).orElse(false)) {
+        if (!logoutProps.map(OAuth2LogoutProperties::isEnabled).orElse(false)) {
             return postLogoutUri.map(URI::toString).filter(StringUtils::hasText);
         }
 

--- a/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/synchronised/client/SpringAddonsLogoutSuccessHandler.java
+++ b/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/synchronised/client/SpringAddonsLogoutSuccessHandler.java
@@ -81,6 +81,6 @@ public class SpringAddonsLogoutSuccessHandler extends SimpleUrlLogoutSuccessHand
 
     @Override
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
-        this.redirectStrategy.sendRedirect(request, response, determineTargetUrl(request, response));
+        this.redirectStrategy.sendRedirect(request, response, determineTargetUrl(request, response, authentication));
     }
 }


### PR DESCRIPTION
Came across this project after reading an article on Baeldung who linked it for good reason.
It's really amazing and I'm really glad I stumbled across it as it's more than helpful setting up and generally getting into oidc and authentication.
However, I had some issues trying to override the end session endpoint provided by the OP discovery as described in the README. When specifying an alternative url in the application properties (oauth2-logout) this url isn't recognized, so I tried to adapt the corresponding parts. Hope this makes sense, thx.
