### PR TITLE
Bugfix NullPointerException

### DIFF
--- a/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/reactive/ReactiveConfigurationSupport.java
+++ b/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/reactive/ReactiveConfigurationSupport.java
@@ -15,7 +15,6 @@ import org.springframework.security.web.server.csrf.CookieServerCsrfTokenReposit
 import org.springframework.security.web.server.csrf.CsrfToken;
 import org.springframework.security.web.server.csrf.ServerCsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.server.csrf.XorServerCsrfTokenRequestAttributeHandler;
-import org.springframework.security.web.server.csrf.CsrfException;
 import org.springframework.util.StringUtils;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
@@ -174,11 +173,20 @@ public class ReactiveConfigurationSupport {
 
         @Override
         public Mono<String> resolveCsrfTokenValue(ServerWebExchange exchange, CsrfToken csrfToken) {
-            final var csfrTokenHeader = exchange.getRequest().getHeaders().get(csrfToken.getHeaderName());
-            if (csfrTokenHeader == null) {
-                throw new CsrfException("An expected CSRF token cannot be found");
-            }
-            final var hasHeader = csfrTokenHeader.stream().filter(StringUtils::hasText).count() > 0;
+            /*
+             * If the request contains a request header, use CsrfTokenRequestAttributeHandler to resolve the CsrfToken. This applies when a single-page
+             * application includes the header value automatically, which was obtained via a cookie containing the raw CsrfToken.
+             *
+             * In all other cases (e.g. if the request contains a request parameter), use XorCsrfTokenRequestAttributeHandler to resolve the CsrfToken.
+             * This applies when a server-side rendered form includes the _csrf request parameter as a hidden input.
+             */
+            // @formatter:off
+            final boolean hasHeader = Optional.ofNullable(exchange.getRequest().getHeaders().get(csrfToken.getHeaderName()))
+                    .orElse(List.of())
+                    .stream()
+                    .filter(StringUtils::hasText)
+                    .count() > 0;
+            // @formatter:on
             return hasHeader ? super.resolveCsrfTokenValue(exchange, csrfToken) : this.delegate.resolveCsrfTokenValue(exchange, csrfToken);
         }
     }

--- a/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/reactive/ReactiveConfigurationSupport.java
+++ b/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/reactive/ReactiveConfigurationSupport.java
@@ -15,6 +15,7 @@ import org.springframework.security.web.server.csrf.CookieServerCsrfTokenReposit
 import org.springframework.security.web.server.csrf.CsrfToken;
 import org.springframework.security.web.server.csrf.ServerCsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.server.csrf.XorServerCsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.server.csrf.CsrfException;
 import org.springframework.util.StringUtils;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
@@ -173,7 +174,11 @@ public class ReactiveConfigurationSupport {
 
         @Override
         public Mono<String> resolveCsrfTokenValue(ServerWebExchange exchange, CsrfToken csrfToken) {
-            final var hasHeader = exchange.getRequest().getHeaders().get(csrfToken.getHeaderName()).stream().filter(StringUtils::hasText).count() > 0;
+            final var csfrTokenHeader = exchange.getRequest().getHeaders().get(csrfToken.getHeaderName());
+            if (csfrTokenHeader == null) {
+                throw new CsrfException("An expected CSRF token cannot be found");
+            }
+            final var hasHeader = csfrTokenHeader.stream().filter(StringUtils::hasText).count() > 0;
             return hasHeader ? super.resolveCsrfTokenValue(exchange, csrfToken) : this.delegate.resolveCsrfTokenValue(exchange, csrfToken);
         }
     }


### PR DESCRIPTION
A NullPointerException is thrown when an HTTP request that is supposed to have an X-XSRF-TOKEN header does not have one.