### PR TITLE
fix document error

### DIFF
--- a/7.0.0-migration-guide.md
+++ b/7.0.0-migration-guide.md
@@ -40,8 +40,8 @@ CORS configuration has also improved for both clients and resource servers: `all
 Resource server `Security(Web)FilterChain` can now be completely disabled with `com.c4-soft.springaddons.security.resourceserver.enabled=false`
 
 Resource server specific properties are grouped in a new `resourceserver` subset:
-- move `cors` down 1 level into `resourceserver` (`com.c4-soft.springaddons.security.cors` becomes `com.c4-soft.springaddons.security.resourceserver.cors`)
-- move `permit-all` down one level to `resourceserver` (`com.c4-soft.springaddons.security.permit-all` becomes `com.c4-soft.springaddons.security.resourceserver.permit-all`)
+- move `cors` down 1 level into `resourceserver` (`com.c4-soft.springaddons.security.cors` becomes `com.c4-soft.springaddons.oidc.resourceserver.cors`)
+- move `permit-all` down one level to `resourceserver` (`com.c4-soft.springaddons.security.permit-all` becomes `com.c4-soft.springaddons.oidc.resourceserver.permit-all`)
 
 ### Clients
 - rename `allowed-origins` to `allowed-origin-patterns` (`com.c4-soft.springaddons.security.client.cors.allowed-origins` becomes `com.c4-soft.springaddons.security.client.cors.allowed-origin-patterns`)


### PR DESCRIPTION
there is document error in upgrade guide.
As defined in class `SpringAddonsOidcProperties`, configuration path should be `com.c4-soft.springaddons.oidc.resourceserver.permit-all` rather than `com.c4-soft.springaddons.security.resourceserver.permit-all`, otherwise it didn't work.