### PR TITLE
gh-249 property to disable SSL certificates validation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Ease OAuth2 / OpenID in Spring RESTful backends
 
-`8.1.4` is :rocket:. It is designed to work with Spring Boot `3.4.3` (Security `6.4.3` and Cloud `2024.0.0`). See [the release notes](https://github.com/ch4mpy/spring-addons/blob/master/release-notes.md#800) for details.
+`8.1.5` is :rocket:. It is designed to work with Spring Boot `3.4.4` (Security `6.4.4` and Cloud `2024.0.1`). See [the release notes](https://github.com/ch4mpy/spring-addons/blob/master/release-notes.md#800) for details.
 
 The new [`spring-addons-starter-rest`](https://github.com/ch4mpy/spring-addons/tree/master/spring-addons-starter-rest) can be a game changer for inter-service calls when OAuth2 or an HTTP proxy is involved. Give it a try!
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.3</version>
+		<version>3.4.4</version>
 	</parent>
 	<groupId>com.c4-soft.springaddons</groupId>
 	<artifactId>spring-addons</artifactId>

--- a/release-notes.md
+++ b/release-notes.md
@@ -5,6 +5,10 @@ For Spring Boot 3.4.x.
 
 `spring-addons-starter-rest` provides auto-configuration for `RestClient`, `WebClient` and tooling for `@HttpExchange` proxy generation.
 
+### `8.1.5`
+- [gh-249](ttps://github.com/ch4mpy/spring-addons/issues/249) Add a property to disable SSL certificates validation for auto-configured REST clients. When `client-http-request-factory-impl=jdk`, only root authority validation is disabled (not the hostname, so the certificate CN or altnames must match the URL hostame). For other request factory implementations (`jdk` and `jetty`), both root authority and hostname validations are disabled.
+- Bump transient dependency on Spring Boot to `3.4.4`
+
 ### `8.1.4`
 - [gh-247](https://github.com/ch4mpy/spring-addons/issues/247) `WebClient` beans auto-configured by `spring-addons-starter-rest` should take the `(Reactive)OAuth2AuthorizedClientManager` from the application context instead of building one from authorized client service and repo.
 

--- a/spring-addons-starter-oidc/README.MD
+++ b/spring-addons-starter-oidc/README.MD
@@ -4,7 +4,7 @@ This project is a Spring Boot starter to use in addition to `spring-boot-starter
 
 ```xml
     <properties>
-        <springaddons.version>8.1.4</springaddons.version>
+        <springaddons.version>8.1.5</springaddons.version>
     </properties>
     
     <dependencies>

--- a/spring-addons-starter-rest/README.md
+++ b/spring-addons-starter-rest/README.md
@@ -8,6 +8,7 @@ This starter aims at auto-configuring `RestClient` and `WebClient` using applica
 - base path (property which can be overridden for each deployment)
 - proxy auto-configuration using `HTTP_PROXY` and `NO_PROXY` environment variables (can be overridden or complemented with properties to, for instance, define credentials for the HTTP proxy)
 - connection and read timeouts
+- disable SSL certificates validation on a per client basis
 - choice of the `RestClient` underlying `ClientHttpRequestFactory`: 
   - `SimpleClientHttpRequestFactory` does not allow `PATCH` requests
   - `JdkClientHttpRequestFactory` is used by default, but it sets headers not supported by some Microsoft middleware
@@ -82,6 +83,9 @@ com:
               read-timeout-millis: 1000
               # requires org.apache.httpcomponents.client5:httpclient5 to be on the class-path
               client-http-request-factory-impl: http-components
+              # disable SSL certificates validation
+              # when "client-http-request-factory-impl" is "jdk", only root authority validation is disabled (not the hostname, so the certificate CN or altnames must match the URL hostame)
+              ssl-certificates-validation-enabled: false
               # Override what is defined in HTTP_PROXY and NO_PROXY environment variables
               proxy:
                 connect-timeout-millis: 500

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/RestMisconfigurationException.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/RestMisconfigurationException.java
@@ -1,9 +1,13 @@
 package com.c4_soft.springaddons.rest;
 
 public class RestMisconfigurationException extends RuntimeException {
-    private static final long serialVersionUID = 681577983030933423L;
+  private static final long serialVersionUID = 681577983030933423L;
 
-    public RestMisconfigurationException(String message) {
-        super(message);
-    }
+  public RestMisconfigurationException(String message) {
+    super(message);
+  }
+
+  public RestMisconfigurationException(Throwable e) {
+    super(e);
+  }
 }

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/SpringAddonsRestProperties.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/SpringAddonsRestProperties.java
@@ -11,7 +11,9 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.http.client.JettyClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.util.StringUtils;
@@ -247,6 +249,14 @@ public class SpringAddonsRestProperties {
       private ClientHttpRequestFactoryImpl clientHttpRequestFactoryImpl =
           ClientHttpRequestFactoryImpl.JDK;
 
+      /**
+       * If false, SSL certificate validation is disabled, which can be handy with self-signed
+       * certificates on a private network. True by default. Note that, in the case with
+       * JdkClientHttpRequestFactory only the root authority check is disabled, meaning that the
+       * self-signed certificate CN claim must be correctly set.
+       */
+      private boolean sslCertificatesValidationEnabled = true;
+
       @Data
       public static class ProxyProperties {
         private boolean enabled = true;
@@ -271,13 +281,13 @@ public class SpringAddonsRestProperties {
          */
         JDK,
         /**
-         * Expose a {@link JdkClientHttpRequestFactory} bean.
+         * Expose an Apache {@link HttpComponentsClientHttpRequestFactory} bean.
          * org.apache.httpcomponents.client5:httpclient5 must be on the class-path.
          */
         HTTP_COMPONENTS,
         /**
-         * Expose a {@link JdkClientHttpRequestFactory} bean. org.eclipse.jetty:jetty-client must be
-         * on the class-path.
+         * Expose a {@link JettyClientHttpRequestFactory} bean. org.eclipse.jetty:jetty-client must
+         * be on the class-path.
          */
         JETTY
       }

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/HttpComponentsClientHttpRequestFactoryHelper.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/HttpComponentsClientHttpRequestFactoryHelper.java
@@ -1,27 +1,46 @@
 package com.c4_soft.springaddons.rest.synchronised;
 
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.impl.routing.DefaultProxyRoutePlanner;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
+import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
+import org.apache.hc.client5.http.ssl.HttpsSupport;
+import org.apache.hc.client5.http.ssl.TrustAllStrategy;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import com.c4_soft.springaddons.rest.ProxySupport;
 import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties;
 
 class HttpComponentsClientHttpRequestFactoryHelper {
-
-  static HttpComponentsClientHttpRequestFactory get(ProxySupport proxySupport,
-      ClientHttpRequestFactoryProperties properties) {
+  public static HttpComponentsClientHttpRequestFactory get(ProxySupport proxySupport,
+      ClientHttpRequestFactoryProperties properties)
+      throws KeyManagementException, NoSuchAlgorithmException, KeyStoreException {
     final var httpClientBuilder = HttpClients.custom();
+
     if (proxySupport != null && proxySupport.isEnabled()) {
       final var proxy = new HttpHost(proxySupport.getHostname().get(), proxySupport.getPort());
       httpClientBuilder.setRoutePlanner(new DefaultProxyRoutePlanner(proxy));
     }
+
+    if (!properties.isSslCertificatesValidationEnabled()) {
+      httpClientBuilder.setConnectionManager(PoolingHttpClientConnectionManagerBuilder.create()
+          .setTlsSocketStrategy(new DefaultClientTlsStrategy(
+              SSLContextBuilder.create().loadTrustMaterial(TrustAllStrategy.INSTANCE).build(),
+              HostnameVerificationPolicy.BOTH, HttpsSupport.getDefaultHostnameVerifier()))
+          .build());
+    }
+
     final var clientHttpRequestFactory =
         new HttpComponentsClientHttpRequestFactory(httpClientBuilder.build());
     properties.getReadTimeoutMillis().map(Duration::ofMillis)
         .ifPresent(clientHttpRequestFactory::setReadTimeout);
+
     return clientHttpRequestFactory;
   }
-
 }

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/JettyClientHttpRequestFactoryHelper.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/JettyClientHttpRequestFactoryHelper.java
@@ -3,13 +3,14 @@ package com.c4_soft.springaddons.rest.synchronised;
 import java.time.Duration;
 import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.Origin;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.springframework.http.client.JettyClientHttpRequestFactory;
 import org.springframework.util.StringUtils;
 import com.c4_soft.springaddons.rest.ProxySupport;
 import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties;
 
 class JettyClientHttpRequestFactoryHelper {
-  static JettyClientHttpRequestFactory get(ProxySupport proxySupport,
+  public static JettyClientHttpRequestFactory get(ProxySupport proxySupport,
       ClientHttpRequestFactoryProperties properties) {
     final var httpClient = new org.eclipse.jetty.client.HttpClient();
 
@@ -19,10 +20,15 @@ class JettyClientHttpRequestFactoryHelper {
           StringUtils.hasText(proxySupport.getPassword()));
       httpClient.getProxyConfiguration().addProxy(httpProxy);
     }
+
+    if (!properties.isSslCertificatesValidationEnabled()) {
+      httpClient.setSslContextFactory(new SslContextFactory.Client(true));
+    }
+
     final var clientHttpRequestFactory = new JettyClientHttpRequestFactory(httpClient);
     properties.getReadTimeoutMillis().map(Duration::ofMillis)
         .ifPresent(clientHttpRequestFactory::setReadTimeout);
+
     return clientHttpRequestFactory;
   }
-
 }


### PR DESCRIPTION
 Possibility to disable SSL certificates validation for an auto-configured REST client with just an application property.

Solves https://github.com/ch4mpy/spring-addons/issues/249