### PR TITLE
style: typo dependency

### DIFF
--- a/spring-addons-starter-rest/README.md
+++ b/spring-addons-starter-rest/README.md
@@ -47,7 +47,7 @@ The following describes the last point. Refer to the docs linked above to genera
 ```xml
 <dependency>
     <groupId>com.c4-soft.springaddons</groupId>
-    <artifactId>spring-addons-starters-rest</artifactId>
+    <artifactId>spring-addons-starter-rest</artifactId>
     <version>${spring-addons.version}</version>
 </dependency>
 ```


### PR DESCRIPTION
# Typo Correction

## Context

This pull request corrects a typo identified in README.md for usage: 
`spring-addons-starter-rest instead` of `spring-addons-starters-rest`

