### PR TITLE
Extended csrf cookie customization

### DIFF
--- a/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/reactive/CookieServerCsrfTokenRepositoryPostProcessor.java
+++ b/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/reactive/CookieServerCsrfTokenRepositoryPostProcessor.java
@@ -1,0 +1,11 @@
+package com.c4_soft.springaddons.security.oidc.starter.reactive;
+
+import org.springframework.security.web.server.csrf.CookieServerCsrfTokenRepository;
+
+/**
+ * Customize the reactive csrf token repository configured by spring-addons
+ */
+@FunctionalInterface
+public interface CookieServerCsrfTokenRepositoryPostProcessor {
+  CookieServerCsrfTokenRepository process(CookieServerCsrfTokenRepository repository);
+}

--- a/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/reactive/client/ReactiveSpringAddonsOidcClientWithLoginBeans.java
+++ b/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/reactive/client/ReactiveSpringAddonsOidcClientWithLoginBeans.java
@@ -51,6 +51,7 @@ import com.c4_soft.springaddons.security.oidc.starter.properties.condition.confi
 import com.c4_soft.springaddons.security.oidc.starter.properties.condition.configuration.IsNotServlet;
 import com.c4_soft.springaddons.security.oidc.starter.reactive.ReactiveConfigurationSupport;
 import com.c4_soft.springaddons.security.oidc.starter.reactive.ReactiveSpringAddonsOidcBeans;
+import com.c4_soft.springaddons.security.oidc.starter.reactive.CookieServerCsrfTokenRepositoryPostProcessor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
@@ -133,6 +134,7 @@ public class ReactiveSpringAddonsOidcClientWithLoginBeans {
    *        applied (default is "isAuthenticated()" to everything that was not matched)
    * @param httpPostProcessor post process the "http" builder just before it is returned (enables to
    *        override anything from the auto-configuration) spring-addons client properties}
+   * @param csrfPostProcessor Optional hook to customize the csrf token repository
    * @param logoutHandler if present, this custom {@link ServerLogoutHandler} is applied.
    * @param oidcBackChannelLogoutHandler if present, Back-Channel Logout is enabled. A default
    *        {@link OidcBackChannelServerLogoutHandler} is provided if
@@ -153,6 +155,7 @@ public class ReactiveSpringAddonsOidcClientWithLoginBeans {
       ServerLogoutSuccessHandler logoutSuccessHandler,
       ClientAuthorizeExchangeSpecPostProcessor authorizePostProcessor,
       ClientReactiveHttpSecurityPostProcessor httpPostProcessor,
+      Optional<CookieServerCsrfTokenRepositoryPostProcessor> csrfPostProcessor,
       Optional<ServerLogoutHandler> logoutHandler, BeanFactory beanFactory) throws Exception {
 
     final var clientRoutes = addonsProperties.getClient().getSecurityMatchers().stream()
@@ -192,7 +195,8 @@ public class ReactiveSpringAddonsOidcClientWithLoginBeans {
           http.oidcLogout(ol -> ol.backChannel(bc -> bc.logoutHandler(handler)));
         }
 
-        ReactiveConfigurationSupport.configureClient(http, serverProperties, addonsProperties, authorizePostProcessor, httpPostProcessor);
+        ReactiveConfigurationSupport.configureClient(http, serverProperties, addonsProperties,
+            authorizePostProcessor, httpPostProcessor, csrfPostProcessor);
 
         return http.build();
     }

--- a/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/reactive/resourceserver/ReactiveSpringAddonsOidcResourceServerBeans.java
+++ b/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/reactive/resourceserver/ReactiveSpringAddonsOidcResourceServerBeans.java
@@ -1,11 +1,7 @@
 package com.c4_soft.springaddons.security.oidc.starter.reactive.resourceserver;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Map;
-
+import java.util.*;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -52,6 +48,7 @@ import com.c4_soft.springaddons.security.oidc.starter.properties.condition.confi
 import com.c4_soft.springaddons.security.oidc.starter.properties.condition.configuration.IsOidcResourceServerCondition;
 import com.c4_soft.springaddons.security.oidc.starter.reactive.ReactiveConfigurationSupport;
 import com.c4_soft.springaddons.security.oidc.starter.reactive.ReactiveSpringAddonsOidcBeans;
+import com.c4_soft.springaddons.security.oidc.starter.reactive.CookieServerCsrfTokenRepositoryPostProcessor;
 
 import reactor.core.publisher.Mono;
 
@@ -103,6 +100,7 @@ public class ReactiveSpringAddonsOidcResourceServerBeans {
 	 * @param  authorizePostProcessor        Hook to override access-control rules for all path that are not listed in "permit-all"
 	 * @param  httpPostProcessor             Hook to override all or part of HttpSecurity auto-configuration
 	 * @param  authenticationManagerResolver Converts successful JWT decoding result into an {@link Authentication}
+	 * @param  csrfPostProcessor             Optional hook to customize the csrf token repository
 	 * @return                               A default {@link SecurityWebFilterChain} for reactive resource-servers with JWT decoder(matches all
 	 *                                       unmatched routes with lowest precedence)
 	 */
@@ -115,12 +113,14 @@ public class ReactiveSpringAddonsOidcResourceServerBeans {
 			SpringAddonsOidcProperties addonsProperties,
 			ResourceServerAuthorizeExchangeSpecPostProcessor authorizePostProcessor,
 			ResourceServerReactiveHttpSecurityPostProcessor httpPostProcessor,
-			ReactiveAuthenticationManagerResolver<ServerWebExchange> authenticationManagerResolver) {
+			ReactiveAuthenticationManagerResolver<ServerWebExchange> authenticationManagerResolver,
+			Optional<CookieServerCsrfTokenRepositoryPostProcessor> csrfPostProcessor) {
 		http.oauth2ResourceServer(server -> {
 			server.authenticationManagerResolver(authenticationManagerResolver);
 		});
 
-		ReactiveConfigurationSupport.configureResourceServer(http, serverProperties, addonsProperties, authorizePostProcessor, httpPostProcessor);
+		ReactiveConfigurationSupport.configureResourceServer(http, serverProperties, addonsProperties,
+			authorizePostProcessor, httpPostProcessor, csrfPostProcessor);
 
 		return http.build();
 	}
@@ -142,6 +142,7 @@ public class ReactiveSpringAddonsOidcResourceServerBeans {
 	 * @param  authorizePostProcessor               Hook to override access-control rules for all path that are not listed in "permit-all"
 	 * @param  httpPostProcessor                    Hook to override all or part of HttpSecurity auto-configuration
 	 * @param  introspectionAuthenticationConverter Converts successful introspection result into an {@link Authentication}
+	 * @param  csrfPostProcessor                    Optional hook to customize the csrf token repository
 	 * @return                                      A default {@link SecurityWebFilterChain} for reactive resource-servers with access-token
 	 *                                              introspection (matches all unmatched routes with lowest precedence)
 	 */
@@ -155,13 +156,15 @@ public class ReactiveSpringAddonsOidcResourceServerBeans {
 			ResourceServerAuthorizeExchangeSpecPostProcessor authorizePostProcessor,
 			ResourceServerReactiveHttpSecurityPostProcessor httpPostProcessor,
 			ReactiveOpaqueTokenAuthenticationConverter introspectionAuthenticationConverter,
-			ReactiveOpaqueTokenIntrospector opaqueTokenIntrospector) {
+			ReactiveOpaqueTokenIntrospector opaqueTokenIntrospector,
+			Optional<CookieServerCsrfTokenRepositoryPostProcessor> csrfPostProcessor) {
 		http.oauth2ResourceServer(server -> server.opaqueToken(ot -> {
 			ot.introspector(opaqueTokenIntrospector);
 			ot.authenticationConverter(introspectionAuthenticationConverter);
 		}));
 
-		ReactiveConfigurationSupport.configureResourceServer(http, serverProperties, addonsProperties, authorizePostProcessor, httpPostProcessor);
+		ReactiveConfigurationSupport.configureResourceServer(http, serverProperties, addonsProperties,
+			authorizePostProcessor, httpPostProcessor, csrfPostProcessor);
 
 		return http.build();
 	}

--- a/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/synchronised/CookieCsrfTokenRepositoryPostProcessor.java
+++ b/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/synchronised/CookieCsrfTokenRepositoryPostProcessor.java
@@ -1,0 +1,11 @@
+package com.c4_soft.springaddons.security.oidc.starter.synchronised;
+
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+
+/**
+ * Customize the servlet csrf token repository configured by spring-addons
+ */
+@FunctionalInterface
+public interface CookieCsrfTokenRepositoryPostProcessor {
+  CookieCsrfTokenRepository process(CookieCsrfTokenRepository repository);
+}

--- a/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/synchronised/client/SpringAddonsOidcClientWithLoginBeans.java
+++ b/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/synchronised/client/SpringAddonsOidcClientWithLoginBeans.java
@@ -50,6 +50,7 @@ import com.c4_soft.springaddons.security.oidc.starter.properties.condition.bean.
 import com.c4_soft.springaddons.security.oidc.starter.properties.condition.configuration.IsClientWithLoginCondition;
 import com.c4_soft.springaddons.security.oidc.starter.synchronised.ServletConfigurationSupport;
 import com.c4_soft.springaddons.security.oidc.starter.synchronised.SpringAddonsOidcBeans;
+import com.c4_soft.springaddons.security.oidc.starter.synchronised.CookieCsrfTokenRepositoryPostProcessor;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -140,6 +141,7 @@ public class SpringAddonsOidcClientWithLoginBeans {
    *        applied (default is "isAuthenticated()" to everything that was not matched)
    * @param httpPostProcessor post process the "http" builder just before it is returned (enables to
    *        override anything from the auto-configuration) spring-addons client properties}
+   * @param csrfPostProcessor Optional hook to customize the csrf token repository
    * @return a security filter-chain scoped to specified security-matchers and adapted to OAuth2
    *         clients
    * @throws Exception in case of miss-configuration
@@ -156,6 +158,7 @@ public class SpringAddonsOidcClientWithLoginBeans {
       InvalidSessionStrategy invalidSessionStrategy, LogoutSuccessHandler logoutSuccessHandler,
       SpringAddonsOidcProperties addonsProperties,
       ClientExpressionInterceptUrlRegistryPostProcessor authorizePostProcessor,
+      Optional<CookieCsrfTokenRepositoryPostProcessor> csrfPostProcessor,
       ClientSynchronizedHttpSecurityPostProcessor httpPostProcessor, BeanFactory beanFactory)
       throws Exception {
     // @formatter:off
@@ -194,7 +197,7 @@ public class SpringAddonsOidcClientWithLoginBeans {
     }
 
     ServletConfigurationSupport.configureClient(http, serverProperties, addonsProperties,
-        authorizePostProcessor, httpPostProcessor);
+        authorizePostProcessor, httpPostProcessor, csrfPostProcessor);
 
     return http.build();
   }

--- a/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/synchronised/resourceserver/SpringAddonsOidcResourceServerBeans.java
+++ b/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/synchronised/resourceserver/SpringAddonsOidcResourceServerBeans.java
@@ -2,10 +2,7 @@
 package com.c4_soft.springaddons.security.oidc.starter.synchronised.resourceserver;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Map;
+import java.util.*;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
@@ -53,6 +50,7 @@ import com.c4_soft.springaddons.security.oidc.starter.properties.condition.bean.
 import com.c4_soft.springaddons.security.oidc.starter.properties.condition.configuration.IsOidcResourceServerCondition;
 import com.c4_soft.springaddons.security.oidc.starter.synchronised.ServletConfigurationSupport;
 import com.c4_soft.springaddons.security.oidc.starter.synchronised.SpringAddonsOidcBeans;
+import com.c4_soft.springaddons.security.oidc.starter.synchronised.CookieCsrfTokenRepositoryPostProcessor;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -105,6 +103,7 @@ public class SpringAddonsOidcResourceServerBeans {
 	 * @param  authorizePostProcessor        Hook to override access-control rules for all path that are not listed in "permit-all"
 	 * @param  httpPostProcessor             Hook to override all or part of HttpSecurity auto-configuration
 	 * @param  authenticationManagerResolver Converts successful JWT decoding result into an {@link Authentication}
+	 * @param  csrfPostProcessor             Optional hook to customize the csrf token repository
 	 * @return                               A {@link SecurityWebFilterChain} for servlet resource-servers with JWT decoder
 	 */
 	@Conditional(IsJwtDecoderResourceServerCondition.class)
@@ -116,13 +115,15 @@ public class SpringAddonsOidcResourceServerBeans {
 			SpringAddonsOidcProperties addonsProperties,
 			ResourceServerExpressionInterceptUrlRegistryPostProcessor authorizePostProcessor,
 			ResourceServerSynchronizedHttpSecurityPostProcessor httpPostProcessor,
-			AuthenticationManagerResolver<HttpServletRequest> authenticationManagerResolver)
+			AuthenticationManagerResolver<HttpServletRequest> authenticationManagerResolver,
+			Optional<CookieCsrfTokenRepositoryPostProcessor> csrfPostProcessor)
 			throws Exception {
 		http.oauth2ResourceServer(oauth2 -> {
 			oauth2.authenticationManagerResolver(authenticationManagerResolver);
 		});
 
-		ServletConfigurationSupport.configureResourceServer(http, serverProperties, addonsProperties, authorizePostProcessor, httpPostProcessor);
+		ServletConfigurationSupport.configureResourceServer(http, serverProperties, addonsProperties,
+		    authorizePostProcessor, httpPostProcessor, csrfPostProcessor);
 
 		return http.build();
 	}
@@ -141,6 +142,7 @@ public class SpringAddonsOidcResourceServerBeans {
 	 * @param  httpPostProcessor                    Hook to override all or part of HttpSecurity auto-configuration
 	 * @param  introspectionAuthenticationConverter Converts successful introspection result into an {@link Authentication}
 	 * @param  opaqueTokenIntrospector              the instrospector to use
+	 * @param  csrfPostProcessor                    Optional hook to customize the csrf token repository
 	 * @return                                      A {@link SecurityWebFilterChain} for servlet resource-servers with access token
 	 *                                              introspection
 	 */
@@ -154,14 +156,16 @@ public class SpringAddonsOidcResourceServerBeans {
 			ResourceServerExpressionInterceptUrlRegistryPostProcessor authorizePostProcessor,
 			ResourceServerSynchronizedHttpSecurityPostProcessor httpPostProcessor,
 			OpaqueTokenAuthenticationConverter introspectionAuthenticationConverter,
-			OpaqueTokenIntrospector opaqueTokenIntrospector)
+			OpaqueTokenIntrospector opaqueTokenIntrospector,
+			Optional<CookieCsrfTokenRepositoryPostProcessor> csrfPostProcessor)
 			throws Exception {
 		http.oauth2ResourceServer(server -> server.opaqueToken(ot -> {
 			ot.introspector(opaqueTokenIntrospector);
 			ot.authenticationConverter(introspectionAuthenticationConverter);
 		}));
 
-		ServletConfigurationSupport.configureResourceServer(http, serverProperties, addonsProperties, authorizePostProcessor, httpPostProcessor);
+		ServletConfigurationSupport.configureResourceServer(http, serverProperties, addonsProperties,
+			authorizePostProcessor, httpPostProcessor, csrfPostProcessor);
 
 		return http.build();
 	}


### PR DESCRIPTION
Hey,

Let me start off by expressing a huge thank you for all the work that has been done here in spring addons. It has become a staple both in- and outside of work, especially for the BFF use-case.

---

As for the PR here, it is a small enhancement to be able to configure some more attributes of the CSRF cookie. It came up because of a requirement at work to include e.g. SameSite attribute on the CSRF cookie as well - which has been achieved, but the solution is kind of messy (declaring an addons server http security post processor bean, and then a choice of the lesser subjective evil - reflection or straight-up copying addons code to be able to add a cookie customizer).

In this PR, I've extracted the existing csrf cookie name & path properties into a new csrf cookie properties class and extended them with the samesite and domain attributes + aligned usage in ReactiveConfigurationSupport & ServletConfigurationSupport.

Please let me know your thoughts and anything I may have missed / you would like to see changed.