### PR TITLE
Allow overriding default X-XSRF-TOKEN header

### DIFF
--- a/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/properties/SpringAddonsOidcClientProperties.java
+++ b/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/properties/SpringAddonsOidcClientProperties.java
@@ -233,13 +233,18 @@ public class SpringAddonsOidcClientProperties {
   private String csrfCookiePath = "/";
 
   /**
+   * Used only when the "csrf" property is set to "COOKIE_ACCESSIBLE_FROM_JS".
+   */
+  private String csrfHeaderName = "X-XSRF-TOKEN";
+
+  /**
    * When true, PKCE is enabled (by default, Spring enables it only for "public" clients)
    */
   private boolean pkceForced = false;
 
   /**
    * Additional parameters to send with authorization request, mapped by client registration IDs
-   * 
+   *
    * @deprecated use the more concise authorization-params syntax
    */
   @Deprecated
@@ -265,7 +270,7 @@ public class SpringAddonsOidcClientProperties {
 
   /**
    * Additional parameters to send with token request, mapped by client registration IDs
-   * 
+   *
    * @deprecated use the more concise token-params syntax
    */
   @Deprecated

--- a/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/properties/SpringAddonsOidcResourceServerProperties.java
+++ b/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/properties/SpringAddonsOidcResourceServerProperties.java
@@ -45,6 +45,11 @@ public class SpringAddonsOidcResourceServerProperties {
   private String csrfCookieName = "XSRF-TOKEN";
 
   /**
+   * Used only when the "csrf" property is set to "COOKIE_ACCESSIBLE_FROM_JS".
+   */
+  private String csrfHeaderName = "X-XSRF-TOKEN";
+
+  /**
    * Used only when the "csrf" property is set to "COOKIE_ACCESSIBLE_FROM_JS". The default value is
    * well supported by Angular and React, but may cause collisions when several applications are
    * hosted on the same backend.

--- a/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/reactive/ReactiveConfigurationSupport.java
+++ b/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/reactive/ReactiveConfigurationSupport.java
@@ -63,6 +63,7 @@ public class ReactiveConfigurationSupport {
         addonsProperties.getResourceserver().getCsrf(),
         addonsProperties.getResourceserver().getCsrfCookieName(),
         addonsProperties.getResourceserver().getCsrfCookiePath(),
+        addonsProperties.getResourceserver().getCsrfHeaderName(),
         csrfPostProcessor);
 
     final var corsProps = new ArrayList<>(addonsProperties.getCors());
@@ -86,9 +87,10 @@ public class ReactiveConfigurationSupport {
       Optional<CookieServerCsrfTokenRepositoryPostProcessor> csrfPostProcessor) {
 
     ReactiveConfigurationSupport.configureState(http, false,
-        addonsProperties.getClient().getCsrf(), 
+        addonsProperties.getClient().getCsrf(),
         addonsProperties.getClient().getCsrfCookieName(),
         addonsProperties.getClient().getCsrfCookiePath(),
+        addonsProperties.getClient().getCsrfHeaderName(),
         csrfPostProcessor);
 
     final var corsProps = new ArrayList<>(addonsProperties.getCors());
@@ -146,7 +148,7 @@ public class ReactiveConfigurationSupport {
   }
 
   public static ServerHttpSecurity configureState(ServerHttpSecurity http, boolean isStatless,
-      Csrf csrfEnum, String csrfCookieName, String csrfCookiePath,
+      Csrf csrfEnum, String csrfCookieName, String csrfCookiePath, String csrfHeaderName,
       Optional<CookieServerCsrfTokenRepositoryPostProcessor> csrfPostProcessor) {
 
     if (isStatless) {
@@ -172,6 +174,7 @@ public class ReactiveConfigurationSupport {
           // adapted from
           // https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#csrf-integration-javascript-spa
           final var repo = CookieServerCsrfTokenRepository.withHttpOnlyFalse();
+          repo.setHeaderName(csrfHeaderName);
           repo.setCookiePath(csrfCookiePath);
           repo.setCookieName(csrfCookieName);
           csrf.csrfTokenRepository(csrfPostProcessor.map(pp -> pp.process(repo)).orElse(repo))

--- a/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/synchronised/ServletConfigurationSupport.java
+++ b/spring-addons-starter-oidc/src/main/java/com/c4_soft/springaddons/security/oidc/starter/synchronised/ServletConfigurationSupport.java
@@ -58,6 +58,7 @@ public class ServletConfigurationSupport {
         addonsProperties.getResourceserver().getCsrf(),
         addonsProperties.getResourceserver().getCsrfCookieName(),
         addonsProperties.getResourceserver().getCsrfCookiePath(),
+        addonsProperties.getResourceserver().getCsrfHeaderName(),
         csrfPostProcessor);
 
     final var corsProps = new ArrayList<>(addonsProperties.getCors());
@@ -80,6 +81,7 @@ public class ServletConfigurationSupport {
     ServletConfigurationSupport.configureState(http, false, addonsProperties.getClient().getCsrf(),
     addonsProperties.getClient().getCsrfCookieName(),
     addonsProperties.getClient().getCsrfCookiePath(),
+    addonsProperties.getClient().getCsrfHeaderName(),
     csrfPostProcessor);
 
     final var corsProps = new ArrayList<>(addonsProperties.getCors());
@@ -139,7 +141,7 @@ public class ServletConfigurationSupport {
   }
 
   public static HttpSecurity configureState(HttpSecurity http, boolean isStatless, Csrf csrfEnum, String csrfCookieName,
-      String csrfCookiePath, Optional<CookieCsrfTokenRepositoryPostProcessor> csrfPostProcessor)
+      String csrfCookiePath, String csrfHeaderName, Optional<CookieCsrfTokenRepositoryPostProcessor> csrfPostProcessor)
       throws Exception {
 
     if (isStatless) {
@@ -163,6 +165,7 @@ public class ServletConfigurationSupport {
           final var repo = CookieCsrfTokenRepository.withHttpOnlyFalse();
           repo.setCookiePath(csrfCookiePath);
           repo.setCookieName(csrfCookieName);
+          repo.setHeaderName(csrfHeaderName);
           configurer.csrfTokenRepository(csrfPostProcessor.map(pp -> pp.process(repo)).orElse(repo))
               .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler());
           break;


### PR DESCRIPTION
Makes it possible to customize CSRF header name to support custom clients and reverse proxy setups