### PR TITLE
gh-298 Allow configuring the HTTP protocol version on the JDK client http request factory

### DIFF
--- a/spring-addons-starter-rest/README.md
+++ b/spring-addons-starter-rest/README.md
@@ -233,7 +233,7 @@ com:
               client-http-request-factory-impl: jetty
 ```
 
-Two extra properties tune the underlying client: `http-protocol-version` (forces the HTTP protocol version) and `use-virtual-threads` (sets the application task executor — the `applicationTaskExecutor` bean — on the client; combine with `spring.threads.virtual.enabled=true` for virtual threads):
+Two extra properties tune the underlying client: `http-protocol-version` (forces the HTTP protocol version) and `use-virtual-threads` (sets the application task executor — the `applicationTaskExecutor` bean, virtual-thread when `spring.threads.virtual.enabled=true` — on the client). `use-virtual-threads` is a boolean that, when left unset, defaults to the value of `spring.threads.virtual.enabled`:
 ```yaml
 com:
   c4-soft:
@@ -247,7 +247,7 @@ com:
 ```
 Support depends on the `client-http-request-factory-impl`:
 - `jdk`: both properties (`http-protocol-version` via the client version, `use-virtual-threads` via the client executor).
-- `jetty`: both properties (`http-protocol-version` via the client transport — `HTTP_2` requires `org.eclipse.jetty.http2:jetty-http2-client` on the class-path; `use-virtual-threads` via the client executor).
+- `jetty`: both properties (`http-protocol-version` via the client transport — `HTTP_2` requires `org.eclipse.jetty.http2:jetty-http2-client` and `jetty-http2-client-transport` on the class-path; `use-virtual-threads` via the client executor).
 - `http-components`: neither — the classic Apache client is HTTP/1.1 only and runs on the calling thread (so already on a virtual thread when the caller is). Both properties are ignored.
 
 ### <a name="ssl-bundles" />2.6. Working with SSL bundles

--- a/spring-addons-starter-rest/README.md
+++ b/spring-addons-starter-rest/README.md
@@ -233,7 +233,7 @@ com:
               client-http-request-factory-impl: jetty
 ```
 
-The JDK implementation accepts two extra properties: `http-protocol-version` (forces the HTTP protocol version) and `use-virtual-threads` (uses a virtual-thread-per-task executor):
+Two extra properties tune the underlying client: `http-protocol-version` (forces the HTTP protocol version) and `use-virtual-threads` (runs the client on virtual threads, requires a Java 21+ runtime):
 ```yaml
 com:
   c4-soft:
@@ -242,10 +242,13 @@ com:
         client:
           machin-client:
             http:
-              # both honored only by the "jdk" client-http-request-factory-impl
               http-protocol-version: HTTP_1_1
               use-virtual-threads: true
 ```
+Support depends on the `client-http-request-factory-impl`:
+- `jdk`: both properties (`http-protocol-version` via the client version, `use-virtual-threads` via the client executor).
+- `jetty`: both properties (`http-protocol-version` via the client transport — `HTTP_2` requires `org.eclipse.jetty.http2:jetty-http2-client` on the class-path; `use-virtual-threads` via the client executor).
+- `http-components`: neither — the classic Apache client is HTTP/1.1 only and runs on the calling thread (so already on a virtual thread when the caller is). Both properties are ignored.
 
 ### <a name="ssl-bundles" />2.6. Working with SSL bundles
 `spring-addons-starter-rest` integrates with Spring Boot SSL bundles (introduced in Boot `3.1`). Lets consider the following Boot configurations for SSL with self signed certificates generated with `openssl req -x509 -newkey rsa:4096 -keyout tls.key -out tls.crt -sha256 -days 3650 -passout pass:change-me -subj "/C=PY/ST=Tahiti/L=Papeete/CN=localhost/emailAddress=ch4mp@c4-soft.com"`:

--- a/spring-addons-starter-rest/README.md
+++ b/spring-addons-starter-rest/README.md
@@ -233,7 +233,7 @@ com:
               client-http-request-factory-impl: jetty
 ```
 
-Two extra properties tune the underlying client: `http-protocol-version` (forces the HTTP protocol version) and `use-virtual-threads` (runs the client on virtual threads, requires a Java 21+ runtime):
+Two extra properties tune the underlying client: `http-protocol-version` (forces the HTTP protocol version) and `use-virtual-threads` (sets the application task executor — the `applicationTaskExecutor` bean — on the client; combine with `spring.threads.virtual.enabled=true` for virtual threads):
 ```yaml
 com:
   c4-soft:

--- a/spring-addons-starter-rest/README.md
+++ b/spring-addons-starter-rest/README.md
@@ -233,6 +233,20 @@ com:
               client-http-request-factory-impl: jetty
 ```
 
+The JDK implementation accepts two extra properties: `http-protocol-version` (forces the HTTP protocol version) and `use-virtual-threads` (uses a virtual-thread-per-task executor):
+```yaml
+com:
+  c4-soft:
+    springaddons:
+      rest:
+        client:
+          machin-client:
+            http:
+              # both honored only by the "jdk" client-http-request-factory-impl
+              http-protocol-version: HTTP_1_1
+              use-virtual-threads: true
+```
+
 ### <a name="ssl-bundles" />2.6. Working with SSL bundles
 `spring-addons-starter-rest` integrates with Spring Boot SSL bundles (introduced in Boot `3.1`). Lets consider the following Boot configurations for SSL with self signed certificates generated with `openssl req -x509 -newkey rsa:4096 -keyout tls.key -out tls.crt -sha256 -days 3650 -passout pass:change-me -subj "/C=PY/ST=Tahiti/L=Papeete/CN=localhost/emailAddress=ch4mp@c4-soft.com"`:
 - on the consumed REST API:

--- a/spring-addons-starter-rest/README.md
+++ b/spring-addons-starter-rest/README.md
@@ -216,7 +216,9 @@ If a `ClientHttpRequestFactory` bean is already configured in the application, `
 - HTTP proxy if properties or `HTTP_PROXY` & `NO_PROXY` environment variables are set
 - timeouts
 
-The default implementation is `JdkClientHttpRequestFactory`. It can can be switched to `HttpComponentsClientHttpRequestFactory` or `JettyClientHttpRequestFactory` using properties:
+The default implementation is `JdkClientHttpRequestFactory`. It can be switched to `HttpComponentsClientHttpRequestFactory` or `JettyClientHttpRequestFactory` using properties.
+
+Two extra properties tune the underlying HTTP client: `http-protocol-version` forces the HTTP protocol version, and `use-virtual-threads` sets the application task executor (the `applicationTaskExecutor` bean, virtual-thread when `spring.threads.virtual.enabled=true`) on the client. When left unset, `use-virtual-threads` defaults to the value of `spring.threads.virtual.enabled`. Support depends on the implementation, as detailed in the comments below:
 ```yaml
 com:
   c4-soft:
@@ -227,28 +229,27 @@ com:
             http:
               # requires org.apache.httpcomponents.client5:httpclient5 to be on the class-path
               client-http-request-factory-impl: http-components
+              # ignored with http-components: the classic Apache client is HTTP/1.1 only
+              http-protocol-version: HTTP_1_1
+              # ignored with http-components: the client runs on the calling thread (already a virtual one when the caller is)
+              use-virtual-threads: true
           bidule-client:
             http:
               # requires org.eclipse.jetty:jetty-client to be on the class-path
               client-http-request-factory-impl: jetty
-```
-
-Two extra properties tune the underlying client: `http-protocol-version` (forces the HTTP protocol version) and `use-virtual-threads` (sets the application task executor — the `applicationTaskExecutor` bean, virtual-thread when `spring.threads.virtual.enabled=true` — on the client). `use-virtual-threads` is a boolean that, when left unset, defaults to the value of `spring.threads.virtual.enabled`:
-```yaml
-com:
-  c4-soft:
-    springaddons:
-      rest:
-        client:
-          machin-client:
+              # HTTP_2 also requires org.eclipse.jetty.http2:jetty-http2-client and jetty-http2-client-transport to be on the class-path
+              http-protocol-version: HTTP_2
+              # runs the Jetty client on the application task executor (virtual threads when spring.threads.virtual.enabled=true)
+              use-virtual-threads: true
+          truc-client:
             http:
+              # jdk (JdkClientHttpRequestFactory) is the default implementation, no extra dependency needed
+              client-http-request-factory-impl: jdk
+              # forces the protocol version on the JDK HTTP client
               http-protocol-version: HTTP_1_1
+              # runs the JDK HTTP client on the application task executor (virtual threads when spring.threads.virtual.enabled=true)
               use-virtual-threads: true
 ```
-Support depends on the `client-http-request-factory-impl`:
-- `jdk`: both properties (`http-protocol-version` via the client version, `use-virtual-threads` via the client executor).
-- `jetty`: both properties (`http-protocol-version` via the client transport — `HTTP_2` requires `org.eclipse.jetty.http2:jetty-http2-client` and `jetty-http2-client-transport` on the class-path; `use-virtual-threads` via the client executor).
-- `http-components`: neither — the classic Apache client is HTTP/1.1 only and runs on the calling thread (so already on a virtual thread when the caller is). Both properties are ignored.
 
 ### <a name="ssl-bundles" />2.6. Working with SSL bundles
 `spring-addons-starter-rest` integrates with Spring Boot SSL bundles (introduced in Boot `3.1`). Lets consider the following Boot configurations for SSL with self signed certificates generated with `openssl req -x509 -newkey rsa:4096 -keyout tls.key -out tls.crt -sha256 -days 3650 -passout pass:change-me -subj "/C=PY/ST=Tahiti/L=Papeete/CN=localhost/emailAddress=ch4mp@c4-soft.com"`:

--- a/spring-addons-starter-rest/pom.xml
+++ b/spring-addons-starter-rest/pom.xml
@@ -89,6 +89,18 @@
             <artifactId>jetty-client</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>jetty-http2-client</artifactId>
+            <version>${jetty.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>jetty-http2-client-transport</artifactId>
+            <version>${jetty.version}</version>
+            <optional>true</optional>
+        </dependency>
 
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/SpringAddonsRestProperties.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/SpringAddonsRestProperties.java
@@ -271,6 +271,12 @@ public class SpringAddonsRestProperties {
        */
       private Optional<java.net.http.HttpClient.Version> httpProtocolVersion = Optional.empty();
 
+      /**
+       * Use a virtual-thread-per-task executor for the underlying client. Honored only by the JDK
+       * {@link ClientHttpRequestFactoryImpl#JDK} implementation.
+       */
+      private boolean useVirtualThreads = false;
+
       @Data
       public static class ProxyProperties {
         private boolean enabled = true;

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/SpringAddonsRestProperties.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/SpringAddonsRestProperties.java
@@ -276,9 +276,10 @@ public class SpringAddonsRestProperties {
        * If true, the application task executor (the {@code applicationTaskExecutor} bean, which runs
        * on virtual threads when {@code spring.threads.virtual.enabled} is true) is set on the
        * underlying client. Honored by the JDK and JETTY implementations (the classic Apache client
-       * runs on the calling thread, so HTTP_COMPONENTS ignores it).
+       * runs on the calling thread, so HTTP_COMPONENTS ignores it). When empty, defaults to the
+       * value of {@code spring.threads.virtual.enabled}.
        */
-      private boolean useVirtualThreads = false;
+      private Optional<Boolean> useVirtualThreads = Optional.empty();
 
       @Data
       public static class ProxyProperties {

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/SpringAddonsRestProperties.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/SpringAddonsRestProperties.java
@@ -264,6 +264,13 @@ public class SpringAddonsRestProperties {
        */
       private boolean sslCertificatesValidationEnabled = true;
 
+      /**
+       * HTTP protocol version to use. Currently honored only by the JDK
+       * {@link ClientHttpRequestFactoryImpl#JDK} implementation (ignored by HTTP_COMPONENTS and
+       * JETTY). When empty, the underlying client default is used.
+       */
+      private Optional<java.net.http.HttpClient.Version> httpProtocolVersion = Optional.empty();
+
       @Data
       public static class ProxyProperties {
         private boolean enabled = true;

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/SpringAddonsRestProperties.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/SpringAddonsRestProperties.java
@@ -265,15 +265,18 @@ public class SpringAddonsRestProperties {
       private boolean sslCertificatesValidationEnabled = true;
 
       /**
-       * HTTP protocol version to use. Currently honored only by the JDK
-       * {@link ClientHttpRequestFactoryImpl#JDK} implementation (ignored by HTTP_COMPONENTS and
-       * JETTY). When empty, the underlying client default is used.
+       * HTTP protocol version to use. Honored by the JDK and JETTY implementations (ignored by
+       * HTTP_COMPONENTS, whose classic client is HTTP/1.1 only). For JETTY, HTTP_2 requires
+       * org.eclipse.jetty.http2:jetty-http2-client on the class-path. When empty, the underlying
+       * client default is used.
        */
       private Optional<java.net.http.HttpClient.Version> httpProtocolVersion = Optional.empty();
 
       /**
-       * Use a virtual-thread-per-task executor for the underlying client. Honored only by the JDK
-       * {@link ClientHttpRequestFactoryImpl#JDK} implementation.
+       * If true, the application task executor (the {@code applicationTaskExecutor} bean, which runs
+       * on virtual threads when {@code spring.threads.virtual.enabled} is true) is set on the
+       * underlying client. Honored by the JDK and JETTY implementations (the classic Apache client
+       * runs on the calling thread, so HTTP_COMPONENTS ignores it).
        */
       private boolean useVirtualThreads = false;
 

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/JettyClientHttpRequestFactoryHelper.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/JettyClientHttpRequestFactoryHelper.java
@@ -1,27 +1,26 @@
 package com.c4_soft.springaddons.rest.synchronised;
 
 import java.time.Duration;
+import java.util.concurrent.Executor;
 import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.Origin;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.http.client.JettyClientHttpRequestFactory;
 import org.springframework.util.StringUtils;
+import org.jspecify.annotations.Nullable;
 import com.c4_soft.springaddons.rest.ProxySupport;
 import com.c4_soft.springaddons.rest.RestMisconfigurationException;
 import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties;
 
 class JettyClientHttpRequestFactoryHelper {
   public static JettyClientHttpRequestFactory get(ProxySupport proxySupport,
-      ClientHttpRequestFactoryProperties properties) {
+      ClientHttpRequestFactoryProperties properties, @Nullable Executor executor) {
     final var httpClient = properties.getHttpProtocolVersion()
         .map(JettyClientHttpRequestFactoryHelper::httpClientForVersion)
         .orElseGet(org.eclipse.jetty.client.HttpClient::new);
 
-    if (properties.isUseVirtualThreads()) {
-      final var executor = new SimpleAsyncTaskExecutor();
-      executor.setVirtualThreads(true);
+    if (executor != null) {
       httpClient.setExecutor(executor);
     }
 

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/JettyClientHttpRequestFactoryHelper.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/JettyClientHttpRequestFactoryHelper.java
@@ -5,6 +5,8 @@ import java.util.concurrent.Executor;
 import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.Origin;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.transport.HttpClientTransportOverHTTP2;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.springframework.http.client.JettyClientHttpRequestFactory;
 import org.springframework.util.StringUtils;
@@ -46,8 +48,15 @@ class JettyClientHttpRequestFactoryHelper {
       java.net.http.HttpClient.Version version) {
     return switch (version) {
       case HTTP_1_1 -> new org.eclipse.jetty.client.HttpClient(new HttpClientTransportOverHTTP());
-      case HTTP_2 -> throw new RestMisconfigurationException(
-          "http-protocol-version HTTP_2 is not supported for the Jetty implementation without org.eclipse.jetty.http2:jetty-http2-client on the class-path");
+      case HTTP_2 -> {
+        try {
+          yield new org.eclipse.jetty.client.HttpClient(
+              new HttpClientTransportOverHTTP2(new HTTP2Client()));
+        } catch (NoClassDefFoundError e) {
+          throw new RestMisconfigurationException(
+              "http-protocol-version HTTP_2 with the Jetty implementation requires org.eclipse.jetty.http2:jetty-http2-client and jetty-http2-client-transport on the class-path");
+        }
+      }
     };
   }
 }

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/JettyClientHttpRequestFactoryHelper.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/JettyClientHttpRequestFactoryHelper.java
@@ -3,16 +3,27 @@ package com.c4_soft.springaddons.rest.synchronised;
 import java.time.Duration;
 import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.Origin;
+import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.http.client.JettyClientHttpRequestFactory;
 import org.springframework.util.StringUtils;
 import com.c4_soft.springaddons.rest.ProxySupport;
+import com.c4_soft.springaddons.rest.RestMisconfigurationException;
 import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties;
 
 class JettyClientHttpRequestFactoryHelper {
   public static JettyClientHttpRequestFactory get(ProxySupport proxySupport,
       ClientHttpRequestFactoryProperties properties) {
-    final var httpClient = new org.eclipse.jetty.client.HttpClient();
+    final var httpClient = properties.getHttpProtocolVersion()
+        .map(JettyClientHttpRequestFactoryHelper::httpClientForVersion)
+        .orElseGet(org.eclipse.jetty.client.HttpClient::new);
+
+    if (properties.isUseVirtualThreads()) {
+      final var executor = new SimpleAsyncTaskExecutor();
+      executor.setVirtualThreads(true);
+      httpClient.setExecutor(executor);
+    }
 
     if (proxySupport != null && proxySupport.isEnabled()) {
       final var httpProxy = new HttpProxy(
@@ -30,5 +41,14 @@ class JettyClientHttpRequestFactoryHelper {
         .ifPresent(clientHttpRequestFactory::setReadTimeout);
 
     return clientHttpRequestFactory;
+  }
+
+  private static org.eclipse.jetty.client.HttpClient httpClientForVersion(
+      java.net.http.HttpClient.Version version) {
+    return switch (version) {
+      case HTTP_1_1 -> new org.eclipse.jetty.client.HttpClient(new HttpClientTransportOverHTTP());
+      case HTTP_2 -> throw new RestMisconfigurationException(
+          "http-protocol-version HTTP_2 is not supported for the Jetty implementation without org.eclipse.jetty.http2:jetty-http2-client on the class-path");
+    };
   }
 }

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/JettyClientHttpRequestFactoryHelper.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/JettyClientHttpRequestFactoryHelper.java
@@ -1,6 +1,7 @@
 package com.c4_soft.springaddons.rest.synchronised;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.Origin;
@@ -10,21 +11,18 @@ import org.eclipse.jetty.http2.client.transport.HttpClientTransportOverHTTP2;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.springframework.http.client.JettyClientHttpRequestFactory;
 import org.springframework.util.StringUtils;
-import org.jspecify.annotations.Nullable;
 import com.c4_soft.springaddons.rest.ProxySupport;
 import com.c4_soft.springaddons.rest.RestMisconfigurationException;
 import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties;
 
 class JettyClientHttpRequestFactoryHelper {
   public static JettyClientHttpRequestFactory get(ProxySupport proxySupport,
-      ClientHttpRequestFactoryProperties properties, @Nullable Executor executor) {
+      ClientHttpRequestFactoryProperties properties, Optional<Executor> executor) {
     final var httpClient = properties.getHttpProtocolVersion()
         .map(JettyClientHttpRequestFactoryHelper::httpClientForVersion)
         .orElseGet(org.eclipse.jetty.client.HttpClient::new);
 
-    if (executor != null) {
-      httpClient.setExecutor(executor);
-    }
+    executor.ifPresent(httpClient::setExecutor);
 
     if (proxySupport != null && proxySupport.isEnabled()) {
       final var httpProxy = new HttpProxy(

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/RestClientBuilderFactoryBean.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/RestClientBuilderFactoryBean.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Executor;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
 import org.springframework.boot.restclient.autoconfigure.RestClientSsl;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -51,15 +52,24 @@ public class RestClientBuilderFactoryBean
 
   private @Nullable Executor virtualThreadsExecutor(
       SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties http) {
-    if (!http.isUseVirtualThreads()) {
+    final boolean useVirtualThreads =
+        http.getUseVirtualThreads().orElseGet(this::isSpringVirtualThreadsEnabled);
+    if (!useVirtualThreads) {
       return null;
     }
     if (applicationContext == null) {
       throw new RestMisconfigurationException(
-          "use-virtual-threads requires an ApplicationContext to resolve the 'applicationTaskExecutor' bean for REST client '%s'"
-              .formatted(clientId));
+          "use-virtual-threads requires an ApplicationContext to resolve the '%s' bean for REST client '%s'"
+              .formatted(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME,
+                  clientId));
     }
-    return applicationContext.getBean("applicationTaskExecutor", Executor.class);
+    return applicationContext.getBean(
+        TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME, Executor.class);
+  }
+
+  private boolean isSpringVirtualThreadsEnabled() {
+    return applicationContext != null && Boolean.TRUE.equals(applicationContext.getEnvironment()
+        .getProperty("spring.threads.virtual.enabled", Boolean.class, Boolean.FALSE));
   }
 
 

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/RestClientBuilderFactoryBean.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/RestClientBuilderFactoryBean.java
@@ -2,9 +2,13 @@ package com.c4_soft.springaddons.rest.synchronised;
 
 import java.net.URL;
 import java.util.Optional;
+import java.util.concurrent.Executor;
 import org.jspecify.annotations.Nullable;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.boot.restclient.autoconfigure.RestClientSsl;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestFactory;
@@ -27,7 +31,8 @@ import lombok.experimental.FieldNameConstants;
 
 @Data
 @FieldNameConstants
-public class RestClientBuilderFactoryBean implements FactoryBean<RestClient.Builder> {
+public class RestClientBuilderFactoryBean
+    implements FactoryBean<RestClient.Builder>, ApplicationContextAware {
   private String clientId;
   private SystemProxyProperties systemProxyProperties = new SystemProxyProperties();
   private SpringAddonsRestProperties restProperties = new SpringAddonsRestProperties();
@@ -37,6 +42,25 @@ public class RestClientBuilderFactoryBean implements FactoryBean<RestClient.Buil
   private Optional<ClientHttpRequestFactory> clientHttpRequestFactory;
   private RestClient.Builder restClientBuilder = RestClient.builder();
   private Optional<RestClientSsl> ssl;
+  private @Nullable ApplicationContext applicationContext;
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    this.applicationContext = applicationContext;
+  }
+
+  private @Nullable Executor virtualThreadsExecutor(
+      SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties http) {
+    if (!http.isUseVirtualThreads()) {
+      return null;
+    }
+    if (applicationContext == null) {
+      throw new RestMisconfigurationException(
+          "use-virtual-threads requires an ApplicationContext to resolve the 'applicationTaskExecutor' bean for REST client '%s'"
+              .formatted(clientId));
+    }
+    return applicationContext.getBean("applicationTaskExecutor", Executor.class);
+  }
 
 
   @Override
@@ -49,7 +73,7 @@ public class RestClientBuilderFactoryBean implements FactoryBean<RestClient.Buil
     // Handle HTTP or SOCK proxy and set timeouts
     builder.requestFactory(clientHttpRequestFactory
         .orElseGet(() -> new SpringAddonsClientHttpRequestFactory(systemProxyProperties,
-            clientProps.getHttp())));
+            clientProps.getHttp(), virtualThreadsExecutor(clientProps.getHttp()))));
 
     clientProps.getBaseUrl().map(URL::toString).ifPresent(builder::baseUrl);
 

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/RestClientBuilderFactoryBean.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/RestClientBuilderFactoryBean.java
@@ -50,12 +50,12 @@ public class RestClientBuilderFactoryBean
     this.applicationContext = applicationContext;
   }
 
-  private @Nullable Executor virtualThreadsExecutor(
+  private Optional<Executor> virtualThreadsExecutor(
       SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties http) {
     final boolean useVirtualThreads =
         http.getUseVirtualThreads().orElseGet(this::isSpringVirtualThreadsEnabled);
     if (!useVirtualThreads) {
-      return null;
+      return Optional.empty();
     }
     if (applicationContext == null) {
       throw new RestMisconfigurationException(
@@ -63,8 +63,8 @@ public class RestClientBuilderFactoryBean
               .formatted(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME,
                   clientId));
     }
-    return applicationContext.getBean(
-        TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME, Executor.class);
+    return Optional.of(applicationContext.getBean(
+        TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME, Executor.class));
   }
 
   private boolean isSpringVirtualThreadsEnabled() {

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/SpringAddonsClientHttpRequestFactory.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/SpringAddonsClientHttpRequestFactory.java
@@ -83,6 +83,7 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
     final var httpClient = HttpClient.newBuilder();
     properties.getConnectTimeoutMillis().map(Duration::ofMillis)
         .ifPresent(httpClient::connectTimeout);
+    properties.getHttpProtocolVersion().ifPresent(httpClient::version);
     return httpClient;
   }
 

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/SpringAddonsClientHttpRequestFactory.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/SpringAddonsClientHttpRequestFactory.java
@@ -18,6 +18,7 @@ import java.util.regex.Pattern;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpRequest;
@@ -84,6 +85,11 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
     properties.getConnectTimeoutMillis().map(Duration::ofMillis)
         .ifPresent(httpClient::connectTimeout);
     properties.getHttpProtocolVersion().ifPresent(httpClient::version);
+    if (properties.isUseVirtualThreads()) {
+      final var executor = new SimpleAsyncTaskExecutor();
+      executor.setVirtualThreads(true);
+      httpClient.executor(executor);
+    }
     return httpClient;
   }
 

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/SpringAddonsClientHttpRequestFactory.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/SpringAddonsClientHttpRequestFactory.java
@@ -14,11 +14,11 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Optional;
+import java.util.concurrent.Executor;
 import java.util.regex.Pattern;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
-import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpRequest;
@@ -41,7 +41,7 @@ import com.c4_soft.springaddons.rest.SystemProxyProperties;
  * When going through a proxy, the Proxy-Authorization header is set if username and password are
  * non-empty.
  * </p>
- * 
+ *
  * @author Jérôme Wacongne &lt;ch4mp&#64;c4-soft.com&gt;
  */
 public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFactory {
@@ -51,16 +51,27 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
 
   public SpringAddonsClientHttpRequestFactory(SystemProxyProperties systemProperties,
       ClientHttpRequestFactoryProperties addonsProperties) {
+    this(systemProperties, addonsProperties, null);
+  }
+
+  /**
+   * @param executor the {@link Executor} to set on the underlying client when use-virtual-threads is
+   *        enabled (typically the application task executor resolved from the context). Honored by
+   *        the JDK and Jetty implementations.
+   */
+  public SpringAddonsClientHttpRequestFactory(SystemProxyProperties systemProperties,
+      ClientHttpRequestFactoryProperties addonsProperties, @Nullable Executor executor) {
     final var proxySupport = new ProxySupport(systemProperties, addonsProperties.getProxy());
 
     this.nonProxyHostsPattern = proxySupport.isEnabled()
         ? Optional.ofNullable(proxySupport.getNoProxy()).map(Pattern::compile)
         : Optional.empty();
 
-    this.noProxyDelegate = clientHttpRequestFactory(null, addonsProperties);
+    this.noProxyDelegate = clientHttpRequestFactory(null, addonsProperties, executor);
 
     if (proxySupport.isEnabled()) {
-      this.proxyDelegate = new ProxyAwareClientHttpRequestFactory(proxySupport, addonsProperties);
+      this.proxyDelegate =
+          new ProxyAwareClientHttpRequestFactory(proxySupport, addonsProperties, executor);
     } else {
       this.proxyDelegate = this.noProxyDelegate;
     }
@@ -79,22 +90,20 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
     return delegate.createRequest(uri, httpMethod);
   }
 
-  private static HttpClient.Builder httpClientBuilder(
-      ClientHttpRequestFactoryProperties properties) {
+  private static HttpClient.Builder httpClientBuilder(ClientHttpRequestFactoryProperties properties,
+      @Nullable Executor executor) {
     final var httpClient = HttpClient.newBuilder();
     properties.getConnectTimeoutMillis().map(Duration::ofMillis)
         .ifPresent(httpClient::connectTimeout);
     properties.getHttpProtocolVersion().ifPresent(httpClient::version);
-    if (properties.isUseVirtualThreads()) {
-      final var executor = new SimpleAsyncTaskExecutor();
-      executor.setVirtualThreads(true);
+    if (executor != null) {
       httpClient.executor(executor);
     }
     return httpClient;
   }
 
   private static ClientHttpRequestFactory clientHttpRequestFactory(ProxySupport proxySupport,
-      ClientHttpRequestFactoryProperties properties) {
+      ClientHttpRequestFactoryProperties properties, @Nullable Executor executor) {
     switch (properties.getClientHttpRequestFactoryImpl()) {
       case HTTP_COMPONENTS:
         try {
@@ -103,10 +112,10 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
           throw new RestMisconfigurationException(e);
         }
       case JETTY:
-        return JettyClientHttpRequestFactoryHelper.get(proxySupport, properties);
+        return JettyClientHttpRequestFactoryHelper.get(proxySupport, properties, executor);
       default:
         try {
-          return jdkClientHttpRequestFactory(proxySupport, properties);
+          return jdkClientHttpRequestFactory(proxySupport, properties, executor);
         } catch (KeyManagementException | NoSuchAlgorithmException e) {
           throw new RestMisconfigurationException(e);
         }
@@ -114,9 +123,9 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
   }
 
   private static JdkClientHttpRequestFactory jdkClientHttpRequestFactory(ProxySupport proxySupport,
-      ClientHttpRequestFactoryProperties properties)
+      ClientHttpRequestFactoryProperties properties, @Nullable Executor executor)
       throws NoSuchAlgorithmException, KeyManagementException {
-    final var httpClientBuilder = httpClientBuilder(properties);
+    final var httpClientBuilder = httpClientBuilder(properties, executor);
     if (proxySupport != null && proxySupport.isEnabled()) {
       final var proxyAddress =
           new InetSocketAddress(proxySupport.getHostname().get(), proxySupport.getPort());
@@ -156,7 +165,7 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
     private final @Nullable String password;
 
     public ProxyAwareClientHttpRequestFactory(ProxySupport proxySupport,
-        ClientHttpRequestFactoryProperties properties) {
+        ClientHttpRequestFactoryProperties properties, @Nullable Executor executor) {
       this.username = proxySupport.getUsername();
       this.password = proxySupport.getPassword();
       final var httpClient = HttpClient.newBuilder();
@@ -165,7 +174,7 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
       httpClient.proxy(ProxySelector.of(proxyAddress));
       properties.getConnectTimeoutMillis().map(Duration::ofMillis)
           .ifPresent(httpClient::connectTimeout);
-      this.delegate = clientHttpRequestFactory(proxySupport, properties);
+      this.delegate = clientHttpRequestFactory(proxySupport, properties, executor);
     }
 
     @Override

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/SpringAddonsClientHttpRequestFactory.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/SpringAddonsClientHttpRequestFactory.java
@@ -51,7 +51,7 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
 
   public SpringAddonsClientHttpRequestFactory(SystemProxyProperties systemProperties,
       ClientHttpRequestFactoryProperties addonsProperties) {
-    this(systemProperties, addonsProperties, null);
+    this(systemProperties, addonsProperties, Optional.empty());
   }
 
   /**
@@ -60,7 +60,7 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
    *        the JDK and Jetty implementations.
    */
   public SpringAddonsClientHttpRequestFactory(SystemProxyProperties systemProperties,
-      ClientHttpRequestFactoryProperties addonsProperties, @Nullable Executor executor) {
+      ClientHttpRequestFactoryProperties addonsProperties, Optional<Executor> executor) {
     final var proxySupport = new ProxySupport(systemProperties, addonsProperties.getProxy());
 
     this.nonProxyHostsPattern = proxySupport.isEnabled()
@@ -91,19 +91,17 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
   }
 
   private static HttpClient.Builder httpClientBuilder(ClientHttpRequestFactoryProperties properties,
-      @Nullable Executor executor) {
+      Optional<Executor> executor) {
     final var httpClient = HttpClient.newBuilder();
     properties.getConnectTimeoutMillis().map(Duration::ofMillis)
         .ifPresent(httpClient::connectTimeout);
     properties.getHttpProtocolVersion().ifPresent(httpClient::version);
-    if (executor != null) {
-      httpClient.executor(executor);
-    }
+    executor.ifPresent(httpClient::executor);
     return httpClient;
   }
 
   private static ClientHttpRequestFactory clientHttpRequestFactory(ProxySupport proxySupport,
-      ClientHttpRequestFactoryProperties properties, @Nullable Executor executor) {
+      ClientHttpRequestFactoryProperties properties, Optional<Executor> executor) {
     switch (properties.getClientHttpRequestFactoryImpl()) {
       case HTTP_COMPONENTS:
         try {
@@ -123,7 +121,7 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
   }
 
   private static JdkClientHttpRequestFactory jdkClientHttpRequestFactory(ProxySupport proxySupport,
-      ClientHttpRequestFactoryProperties properties, @Nullable Executor executor)
+      ClientHttpRequestFactoryProperties properties, Optional<Executor> executor)
       throws NoSuchAlgorithmException, KeyManagementException {
     final var httpClientBuilder = httpClientBuilder(properties, executor);
     if (proxySupport != null && proxySupport.isEnabled()) {
@@ -165,7 +163,7 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
     private final @Nullable String password;
 
     public ProxyAwareClientHttpRequestFactory(ProxySupport proxySupport,
-        ClientHttpRequestFactoryProperties properties, @Nullable Executor executor) {
+        ClientHttpRequestFactoryProperties properties, Optional<Executor> executor) {
       this.username = proxySupport.getUsername();
       this.password = proxySupport.getPassword();
       final var httpClient = HttpClient.newBuilder();

--- a/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/SpringAddonsClientHttpRequestFactoryHttpVersionTest.java
+++ b/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/SpringAddonsClientHttpRequestFactoryHttpVersionTest.java
@@ -1,0 +1,50 @@
+package com.c4_soft.springaddons.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.ClientHttpRequest;
+import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties;
+import com.c4_soft.springaddons.rest.synchronised.SpringAddonsClientHttpRequestFactory;
+
+/**
+ * Verifies that the optional {@code http.http-protocol-version} property is applied to the JDK
+ * {@link HttpClient} built by {@link SpringAddonsClientHttpRequestFactory}.
+ */
+class SpringAddonsClientHttpRequestFactoryHttpVersionTest {
+
+  @Test
+  void givenHttpProtocolVersionIsSet_whenCreatingRequest_thenJdkHttpClientUsesIt()
+      throws Exception {
+    final var http = new ClientHttpRequestFactoryProperties();
+    http.setHttpProtocolVersion(Optional.of(HttpClient.Version.HTTP_1_1));
+
+    final var httpClient = jdkHttpClientFor(http);
+
+    assertEquals(HttpClient.Version.HTTP_1_1, httpClient.version());
+  }
+
+  @Test
+  void givenHttpProtocolVersionIsNotSet_whenCreatingRequest_thenJdkHttpClientUsesItsDefault()
+      throws Exception {
+    final var http = new ClientHttpRequestFactoryProperties();
+
+    final var httpClient = jdkHttpClientFor(http);
+
+    // The JDK HttpClient defaults to HTTP/2 when no version is configured.
+    assertEquals(HttpClient.Version.HTTP_2, httpClient.version());
+  }
+
+  private static HttpClient jdkHttpClientFor(ClientHttpRequestFactoryProperties http)
+      throws Exception {
+    final var factory = new SpringAddonsClientHttpRequestFactory(new SystemProxyProperties(), http);
+    final ClientHttpRequest request =
+        factory.createRequest(URI.create("https://localhost/test"), HttpMethod.GET);
+    final var httpClientField = request.getClass().getDeclaredField("httpClient");
+    httpClientField.setAccessible(true);
+    return (HttpClient) httpClientField.get(request);
+  }
+}

--- a/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/SpringAddonsClientHttpRequestFactoryJettyVersionTest.java
+++ b/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/SpringAddonsClientHttpRequestFactoryJettyVersionTest.java
@@ -1,18 +1,17 @@
 package com.c4_soft.springaddons.rest;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.net.http.HttpClient;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import com.c4_soft.springaddons.rest.RestMisconfigurationException;
 import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties;
 import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties.ClientHttpRequestFactoryImpl;
 import com.c4_soft.springaddons.rest.synchronised.SpringAddonsClientHttpRequestFactory;
 
 /**
- * Verifies the {@code http.http-protocol-version} mapping for the Jetty implementation: HTTP/1.1 is
- * configured through the over-HTTP transport, HTTP/2 fails fast (it requires jetty-http2-client).
+ * Verifies the {@code http.http-protocol-version} mapping for the Jetty implementation: HTTP/1.1
+ * goes through the over-HTTP transport and HTTP/2 through the over-HTTP/2 transport (the
+ * jetty-http2-client dependencies are on the test class-path).
  */
 class SpringAddonsClientHttpRequestFactoryJettyVersionTest {
 
@@ -27,12 +26,12 @@ class SpringAddonsClientHttpRequestFactoryJettyVersionTest {
   }
 
   @Test
-  void givenJettyAndHttp2_whenBuildingFactory_thenThrows() {
+  void givenJettyAndHttp2_whenBuildingFactory_thenSucceeds() {
     final var http = new ClientHttpRequestFactoryProperties();
     http.setClientHttpRequestFactoryImpl(ClientHttpRequestFactoryImpl.JETTY);
     http.setHttpProtocolVersion(Optional.of(HttpClient.Version.HTTP_2));
 
-    assertThrows(RestMisconfigurationException.class,
+    assertDoesNotThrow(
         () -> new SpringAddonsClientHttpRequestFactory(new SystemProxyProperties(), http));
   }
 }

--- a/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/SpringAddonsClientHttpRequestFactoryJettyVersionTest.java
+++ b/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/SpringAddonsClientHttpRequestFactoryJettyVersionTest.java
@@ -1,0 +1,38 @@
+package com.c4_soft.springaddons.rest;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.net.http.HttpClient;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import com.c4_soft.springaddons.rest.RestMisconfigurationException;
+import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties;
+import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties.ClientHttpRequestFactoryImpl;
+import com.c4_soft.springaddons.rest.synchronised.SpringAddonsClientHttpRequestFactory;
+
+/**
+ * Verifies the {@code http.http-protocol-version} mapping for the Jetty implementation: HTTP/1.1 is
+ * configured through the over-HTTP transport, HTTP/2 fails fast (it requires jetty-http2-client).
+ */
+class SpringAddonsClientHttpRequestFactoryJettyVersionTest {
+
+  @Test
+  void givenJettyAndHttp1_1_whenBuildingFactory_thenSucceeds() {
+    final var http = new ClientHttpRequestFactoryProperties();
+    http.setClientHttpRequestFactoryImpl(ClientHttpRequestFactoryImpl.JETTY);
+    http.setHttpProtocolVersion(Optional.of(HttpClient.Version.HTTP_1_1));
+
+    assertDoesNotThrow(
+        () -> new SpringAddonsClientHttpRequestFactory(new SystemProxyProperties(), http));
+  }
+
+  @Test
+  void givenJettyAndHttp2_whenBuildingFactory_thenThrows() {
+    final var http = new ClientHttpRequestFactoryProperties();
+    http.setClientHttpRequestFactoryImpl(ClientHttpRequestFactoryImpl.JETTY);
+    http.setHttpProtocolVersion(Optional.of(HttpClient.Version.HTTP_2));
+
+    assertThrows(RestMisconfigurationException.class,
+        () -> new SpringAddonsClientHttpRequestFactory(new SystemProxyProperties(), http));
+  }
+}

--- a/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/SpringAddonsClientHttpRequestFactoryVirtualThreadsTest.java
+++ b/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/SpringAddonsClientHttpRequestFactoryVirtualThreadsTest.java
@@ -1,0 +1,47 @@
+package com.c4_soft.springaddons.rest;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.net.URI;
+import java.net.http.HttpClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.ClientHttpRequest;
+import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties;
+import com.c4_soft.springaddons.rest.synchronised.SpringAddonsClientHttpRequestFactory;
+
+/**
+ * Verifies that the {@code http.use-virtual-threads} property sets an executor on the JDK
+ * {@link HttpClient} built by {@link SpringAddonsClientHttpRequestFactory}.
+ */
+class SpringAddonsClientHttpRequestFactoryVirtualThreadsTest {
+
+  @Test
+  @EnabledForJreRange(min = JRE.JAVA_21) // virtual threads require Java 21+
+  void givenUseVirtualThreads_whenCreatingRequest_thenTheJdkHttpClientHasAnExecutor()
+      throws Exception {
+    final var http = new ClientHttpRequestFactoryProperties();
+    http.setUseVirtualThreads(true);
+
+    assertTrue(jdkHttpClientFor(http).executor().isPresent());
+  }
+
+  @Test
+  void givenUseVirtualThreadsDisabled_whenCreatingRequest_thenTheJdkHttpClientHasNoExplicitExecutor()
+      throws Exception {
+    final var http = new ClientHttpRequestFactoryProperties();
+
+    assertTrue(jdkHttpClientFor(http).executor().isEmpty());
+  }
+
+  private static HttpClient jdkHttpClientFor(ClientHttpRequestFactoryProperties http)
+      throws Exception {
+    final var factory = new SpringAddonsClientHttpRequestFactory(new SystemProxyProperties(), http);
+    final ClientHttpRequest request =
+        factory.createRequest(URI.create("https://localhost/test"), HttpMethod.GET);
+    final var httpClientField = request.getClass().getDeclaredField("httpClient");
+    httpClientField.setAccessible(true);
+    return (HttpClient) httpClientField.get(request);
+  }
+}

--- a/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/SpringAddonsClientHttpRequestFactoryVirtualThreadsTest.java
+++ b/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/SpringAddonsClientHttpRequestFactoryVirtualThreadsTest.java
@@ -3,41 +3,43 @@ package com.c4_soft.springaddons.rest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.util.concurrent.Executor;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpRequest;
 import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties;
 import com.c4_soft.springaddons.rest.synchronised.SpringAddonsClientHttpRequestFactory;
 
 /**
- * Verifies that the {@code http.use-virtual-threads} property sets an executor on the JDK
- * {@link HttpClient} built by {@link SpringAddonsClientHttpRequestFactory}.
+ * Verifies that the {@link Executor} passed to {@link SpringAddonsClientHttpRequestFactory} (resolved
+ * from the context when use-virtual-threads is enabled) is set on the JDK {@link HttpClient}.
  */
 class SpringAddonsClientHttpRequestFactoryVirtualThreadsTest {
 
   @Test
-  @EnabledForJreRange(min = JRE.JAVA_21) // virtual threads require Java 21+
-  void givenUseVirtualThreads_whenCreatingRequest_thenTheJdkHttpClientHasAnExecutor()
-      throws Exception {
+  void givenAnExecutor_whenCreatingRequest_thenTheJdkHttpClientUsesIt() throws Exception {
     final var http = new ClientHttpRequestFactoryProperties();
-    http.setUseVirtualThreads(true);
+    final Executor executor = Runnable::run;
 
-    assertTrue(jdkHttpClientFor(http).executor().isPresent());
+    final var factory =
+        new SpringAddonsClientHttpRequestFactory(new SystemProxyProperties(), http, executor);
+
+    assertTrue(jdkHttpClientOf(factory).executor().isPresent());
   }
 
   @Test
-  void givenUseVirtualThreadsDisabled_whenCreatingRequest_thenTheJdkHttpClientHasNoExplicitExecutor()
+  void givenNoExecutor_whenCreatingRequest_thenTheJdkHttpClientHasNoExplicitExecutor()
       throws Exception {
     final var http = new ClientHttpRequestFactoryProperties();
 
-    assertTrue(jdkHttpClientFor(http).executor().isEmpty());
+    final var factory =
+        new SpringAddonsClientHttpRequestFactory(new SystemProxyProperties(), http);
+
+    assertTrue(jdkHttpClientOf(factory).executor().isEmpty());
   }
 
-  private static HttpClient jdkHttpClientFor(ClientHttpRequestFactoryProperties http)
+  private static HttpClient jdkHttpClientOf(SpringAddonsClientHttpRequestFactory factory)
       throws Exception {
-    final var factory = new SpringAddonsClientHttpRequestFactory(new SystemProxyProperties(), http);
     final ClientHttpRequest request =
         factory.createRequest(URI.create("https://localhost/test"), HttpMethod.GET);
     final var httpClientField = request.getClass().getDeclaredField("httpClient");

--- a/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/SpringAddonsClientHttpRequestFactoryVirtualThreadsTest.java
+++ b/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/SpringAddonsClientHttpRequestFactoryVirtualThreadsTest.java
@@ -3,6 +3,7 @@ package com.c4_soft.springaddons.rest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
@@ -21,8 +22,8 @@ class SpringAddonsClientHttpRequestFactoryVirtualThreadsTest {
     final var http = new ClientHttpRequestFactoryProperties();
     final Executor executor = Runnable::run;
 
-    final var factory =
-        new SpringAddonsClientHttpRequestFactory(new SystemProxyProperties(), http, executor);
+    final var factory = new SpringAddonsClientHttpRequestFactory(new SystemProxyProperties(), http,
+        Optional.of(executor));
 
     assertTrue(jdkHttpClientOf(factory).executor().isPresent());
   }


### PR DESCRIPTION
Part of #298.                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                            
  Adds two per-client properties to tune the underlying HTTP client, with                                                                                                                                                                                                                                                   
  per-implementation support:                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                            
  - `http-protocol-version` — forces the HTTP protocol version                                                                                                                                                                                                                                                              
  - `use-virtual-threads` — sets the application task executor (the                                                                                                                                                                                                                                                         
    `applicationTaskExecutor` bean, resolved from the context — virtual-thread when                                                                                                                                                                                                                                         
    `spring.threads.virtual.enabled=true`) on the client                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                            
  Implementation support:                                                                                                                                                                                                                                                                                                   
  - `jdk`: both — `http-protocol-version` via `HttpClient.Builder.version(...)`,                                                                                                                                                                                                                                            
    `use-virtual-threads` via the client executor                                                                                                                                                                                                                                                                           
  - `jetty`: both — `http-protocol-version` via the client transport (`HTTP_2` requires                                                                                                                                                                                                                                     
    `org.eclipse.jetty.http2:jetty-http2-client`); `use-virtual-threads` via                                                                                                                                                                                                                                                
    `HttpClient.setExecutor(...)`                                                                                                                                                                                                                                                                                           
  - `http-components`: neither — the classic Apache client is HTTP/1.1 only and runs on the                                                                                                                                                                                                                                 
    calling thread (already on a virtual thread when the caller is), so both are ignored                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                            
  `RestClientBuilderFactoryBean` becomes `ApplicationContextAware` to resolve the executor.                                                                                                                                                                                                                                 
  README updated with the per-implementation matrix. Tests included.