### PR TITLE
gh-298 Add a per-client request factory customizer

### DIFF
--- a/spring-addons-starter-rest/README.md
+++ b/spring-addons-starter-rest/README.md
@@ -218,37 +218,64 @@ If a `ClientHttpRequestFactory` bean is already configured in the application, `
 
 The default implementation is `JdkClientHttpRequestFactory`. It can be switched to `HttpComponentsClientHttpRequestFactory` or `JettyClientHttpRequestFactory` using properties.
 
-Two extra properties tune the underlying HTTP client: `http-protocol-version` forces the HTTP protocol version, and `use-virtual-threads` sets the application task executor (the `applicationTaskExecutor` bean, virtual-thread when `spring.threads.virtual.enabled=true`) on the client. When left unset, `use-virtual-threads` defaults to the value of `spring.threads.virtual.enabled`. Support depends on the implementation, as detailed in the comments below:
+Three extra properties tune the underlying HTTP client: `http-protocol-version` forces the HTTP protocol version, `use-virtual-threads` sets the application task executor (the `applicationTaskExecutor` bean, virtual-thread when `spring.threads.virtual.enabled=true`) on the client, and `http-client-builder-consumer-bean` names a `Consumer` bean applied to the implementation-specific client builder just before the request factory is built — for whatever is not exposed as properties. Support depends on the implementation, as detailed in the comments below:
 ```yaml
 com:
   c4-soft:
     springaddons:
       rest:
         client:
-          machin-client:
+          jdk-sample-client:
+            http:
+              # both HTTP_1_1 and HTTP_2 are supported
+              http-protocol-version: HTTP_2
+
+              # requires spring.threads.virtual.enabled to be true
+              # you probably don't need to set this property as it defaults to ${spring.threads.virtual.enabled}
+              use-virtual-threads: ${spring.threads.virtual.enabled}
+
+              # the qualifier of a Consumer<java.net.http.HttpClient.Builder>
+              http-client-builder-consumer-bean: jdkHttpClientBuilderConsumer
+
+          httpcomponents-sample-client:
             http:
               # requires org.apache.httpcomponents.client5:httpclient5 to be on the class-path
               client-http-request-factory-impl: http-components
-              # ignored with http-components: the classic Apache client is HTTP/1.1 only
-              http-protocol-version: HTTP_1_1
-              # ignored with http-components: the client runs on the calling thread (already a virtual one when the caller is)
-              use-virtual-threads: true
-          bidule-client:
+
+              # these properties are ignored for httpcomponents
+              http-protocol-version:
+              use-virtual-threads:
+
+              # the qualifier of a Consumer<org.apache.hc.client5.http.impl.classic.HttpClientBuilder>
+              http-client-builder-consumer-bean: httpComponentsHttpClientBuilderConsumer
+
+          jetty-sample-client:
             http:
               # requires org.eclipse.jetty:jetty-client to be on the class-path
               client-http-request-factory-impl: jetty
               # HTTP_2 also requires org.eclipse.jetty.http2:jetty-http2-client and jetty-http2-client-transport to be on the class-path
               http-protocol-version: HTTP_2
-              # runs the Jetty client on the application task executor (virtual threads when spring.threads.virtual.enabled=true)
-              use-virtual-threads: true
-          truc-client:
-            http:
-              # jdk (JdkClientHttpRequestFactory) is the default implementation, no extra dependency needed
-              client-http-request-factory-impl: jdk
-              # forces the protocol version on the JDK HTTP client
-              http-protocol-version: HTTP_1_1
-              # runs the JDK HTTP client on the application task executor (virtual threads when spring.threads.virtual.enabled=true)
-              use-virtual-threads: true
+              use-virtual-threads: ${spring.threads.virtual.enabled}
+
+              # the qualifier of a Consumer<org.eclipse.jetty.client.HttpClient>
+              http-client-builder-consumer-bean: jettyHttpClientBuilderConsumer
+```
+With:
+```java
+@Bean
+Consumer<java.net.http.HttpClient.Builder> jdkHttpClientBuilderConsumer() {
+  return builder -> { /* TODO: implement */ };
+}
+
+@Bean
+Consumer<org.apache.hc.client5.http.impl.classic.HttpClientBuilder> httpComponentsHttpClientBuilderConsumer() {
+  return builder -> { /* TODO: implement */ };
+}
+
+@Bean
+Consumer<org.eclipse.jetty.client.HttpClient> jettyHttpClientBuilderConsumer() {
+  return builder -> { /* TODO: implement */ };
+}
 ```
 
 ### <a name="ssl-bundles" />2.6. Working with SSL bundles

--- a/spring-addons-starter-rest/README.md
+++ b/spring-addons-starter-rest/README.md
@@ -234,7 +234,7 @@ com:
               # you probably don't need to set this property as it defaults to ${spring.threads.virtual.enabled}
               use-virtual-threads: ${spring.threads.virtual.enabled}
 
-              # the qualifier of a Consumer<java.net.http.HttpClient.Builder>
+              # the name of a Consumer<java.net.http.HttpClient.Builder> bean
               http-client-builder-consumer-bean: jdkHttpClientBuilderConsumer
 
           httpcomponents-sample-client:
@@ -246,7 +246,7 @@ com:
               http-protocol-version:
               use-virtual-threads:
 
-              # the qualifier of a Consumer<org.apache.hc.client5.http.impl.classic.HttpClientBuilder>
+              # the name of a Consumer<org.apache.hc.client5.http.impl.classic.HttpClientBuilder> bean
               http-client-builder-consumer-bean: httpComponentsHttpClientBuilderConsumer
 
           jetty-sample-client:
@@ -257,7 +257,7 @@ com:
               http-protocol-version: HTTP_2
               use-virtual-threads: ${spring.threads.virtual.enabled}
 
-              # the qualifier of a Consumer<org.eclipse.jetty.client.HttpClient>
+              # the name of a Consumer<org.eclipse.jetty.client.HttpClient> bean
               http-client-builder-consumer-bean: jettyHttpClientBuilderConsumer
 ```
 With:

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/SpringAddonsRestProperties.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/SpringAddonsRestProperties.java
@@ -267,8 +267,8 @@ public class SpringAddonsRestProperties {
       /**
        * HTTP protocol version to use. Honored by the JDK and JETTY implementations (ignored by
        * HTTP_COMPONENTS, whose classic client is HTTP/1.1 only). For JETTY, HTTP_2 requires
-       * org.eclipse.jetty.http2:jetty-http2-client on the class-path. When empty, the underlying
-       * client default is used.
+       * org.eclipse.jetty.http2:jetty-http2-client and jetty-http2-client-transport on the
+       * class-path. When empty, the underlying client default is used.
        */
       private Optional<java.net.http.HttpClient.Version> httpProtocolVersion = Optional.empty();
 
@@ -280,6 +280,16 @@ public class SpringAddonsRestProperties {
        * value of {@code spring.threads.virtual.enabled}.
        */
       private Optional<Boolean> useVirtualThreads = Optional.empty();
+
+      /**
+       * Name of a {@link java.util.function.Consumer} bean applied to the underlying client builder
+       * of the configured {@link #clientHttpRequestFactoryImpl} just before the request factory is
+       * built. Enables configuration that is not exposed as properties. The expected consumed type
+       * depends on the implementation: {@code java.net.http.HttpClient.Builder} for JDK,
+       * {@code org.apache.hc.client5.http.impl.classic.HttpClientBuilder} for HTTP_COMPONENTS and
+       * {@code org.eclipse.jetty.client.HttpClient} for JETTY.
+       */
+      private Optional<String> httpClientBuilderConsumerBean = Optional.empty();
 
       @Data
       public static class ProxyProperties {

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/SpringAddonsRestProperties.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/SpringAddonsRestProperties.java
@@ -283,7 +283,7 @@ public class SpringAddonsRestProperties {
 
       /**
        * Name of a {@link java.util.function.Consumer} bean applied to the underlying client builder
-       * of the configured {@link #clientHttpRequestFactoryImpl} just before the request factory is
+       * of the configured client-http-request-factory-impl just before the request factory is
        * built. Enables configuration that is not exposed as properties. The expected consumed type
        * depends on the implementation: {@code java.net.http.HttpClient.Builder} for JDK,
        * {@code org.apache.hc.client5.http.impl.classic.HttpClientBuilder} for HTTP_COMPONENTS and

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/HttpComponentsClientHttpRequestFactoryHelper.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/HttpComponentsClientHttpRequestFactoryHelper.java
@@ -4,6 +4,9 @@ import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.impl.routing.DefaultProxyRoutePlanner;
@@ -19,7 +22,8 @@ import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProper
 
 class HttpComponentsClientHttpRequestFactoryHelper {
   public static HttpComponentsClientHttpRequestFactory get(ProxySupport proxySupport,
-      ClientHttpRequestFactoryProperties properties)
+      ClientHttpRequestFactoryProperties properties,
+      Optional<Consumer<HttpClientBuilder>> httpClientBuilderConsumer)
       throws KeyManagementException, NoSuchAlgorithmException, KeyStoreException {
     final var httpClientBuilder = HttpClients.custom();
 
@@ -35,6 +39,8 @@ class HttpComponentsClientHttpRequestFactoryHelper {
               HostnameVerificationPolicy.BOTH, HttpsSupport.getDefaultHostnameVerifier()))
           .build());
     }
+
+    httpClientBuilderConsumer.ifPresent(consumer -> consumer.accept(httpClientBuilder));
 
     final var clientHttpRequestFactory =
         new HttpComponentsClientHttpRequestFactory(httpClientBuilder.build());

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/JettyClientHttpRequestFactoryHelper.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/JettyClientHttpRequestFactoryHelper.java
@@ -3,6 +3,7 @@ package com.c4_soft.springaddons.rest.synchronised;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.Origin;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
@@ -17,7 +18,8 @@ import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProper
 
 class JettyClientHttpRequestFactoryHelper {
   public static JettyClientHttpRequestFactory get(ProxySupport proxySupport,
-      ClientHttpRequestFactoryProperties properties, Optional<Executor> executor) {
+      ClientHttpRequestFactoryProperties properties, Optional<Executor> executor,
+      Optional<Consumer<org.eclipse.jetty.client.HttpClient>> httpClientBuilderConsumer) {
     final var httpClient = properties.getHttpProtocolVersion()
         .map(JettyClientHttpRequestFactoryHelper::httpClientForVersion)
         .orElseGet(org.eclipse.jetty.client.HttpClient::new);
@@ -34,6 +36,8 @@ class JettyClientHttpRequestFactoryHelper {
     if (!properties.isSslCertificatesValidationEnabled()) {
       httpClient.setSslContextFactory(new SslContextFactory.Client(true));
     }
+
+    httpClientBuilderConsumer.ifPresent(consumer -> consumer.accept(httpClient));
 
     final var clientHttpRequestFactory = new JettyClientHttpRequestFactory(httpClient);
     properties.getReadTimeoutMillis().map(Duration::ofMillis)

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/RestClientBuilderFactoryBean.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/RestClientBuilderFactoryBean.java
@@ -81,12 +81,11 @@ public class RestClientBuilderFactoryBean
     final var beanName = http.getHttpClientBuilderConsumerBean().get();
     if (applicationContext == null) {
       throw new RestMisconfigurationException(
-          "Cannot resolve http-client-builder-consumer-bean '%s' for REST client '%s': no ApplicationContext available"
+          "http-client-builder-consumer-bean requires an ApplicationContext to resolve the '%s' bean for REST client '%s'"
               .formatted(beanName, clientId));
     }
     return Optional.of(applicationContext.getBean(beanName, Consumer.class));
   }
-
 
   @Override
   public RestClient.Builder getObject() throws Exception {

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/RestClientBuilderFactoryBean.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/RestClientBuilderFactoryBean.java
@@ -3,6 +3,7 @@ package com.c4_soft.springaddons.rest.synchronised;
 import java.net.URL;
 import java.util.Optional;
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.FactoryBean;
@@ -72,6 +73,20 @@ public class RestClientBuilderFactoryBean
         .getProperty("spring.threads.virtual.enabled", Boolean.class, Boolean.FALSE));
   }
 
+  private Optional<Consumer<?>> httpClientBuilderConsumer(
+      SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties http) {
+    if (http.getHttpClientBuilderConsumerBean().isEmpty()) {
+      return Optional.empty();
+    }
+    final var beanName = http.getHttpClientBuilderConsumerBean().get();
+    if (applicationContext == null) {
+      throw new RestMisconfigurationException(
+          "Cannot resolve http-client-builder-consumer-bean '%s' for REST client '%s': no ApplicationContext available"
+              .formatted(beanName, clientId));
+    }
+    return Optional.of(applicationContext.getBean(beanName, Consumer.class));
+  }
+
 
   @Override
   public RestClient.Builder getObject() throws Exception {
@@ -83,7 +98,8 @@ public class RestClientBuilderFactoryBean
     // Handle HTTP or SOCK proxy and set timeouts
     builder.requestFactory(clientHttpRequestFactory
         .orElseGet(() -> new SpringAddonsClientHttpRequestFactory(systemProxyProperties,
-            clientProps.getHttp(), virtualThreadsExecutor(clientProps.getHttp()))));
+            clientProps.getHttp(), virtualThreadsExecutor(clientProps.getHttp()),
+            httpClientBuilderConsumer(clientProps.getHttp()))));
 
     clientProps.getBaseUrl().map(URL::toString).ifPresent(builder::baseUrl);
 

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/RestClientFactoryBean.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/RestClientFactoryBean.java
@@ -2,8 +2,11 @@ package com.c4_soft.springaddons.rest.synchronised;
 
 import java.util.Optional;
 import org.jspecify.annotations.Nullable;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.boot.restclient.autoconfigure.RestClientSsl;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
@@ -16,7 +19,7 @@ import lombok.experimental.FieldNameConstants;
 
 @Setter
 @FieldNameConstants
-public class RestClientFactoryBean implements FactoryBean<RestClient> {
+public class RestClientFactoryBean implements FactoryBean<RestClient>, ApplicationContextAware {
   private String clientId;
   private SystemProxyProperties systemProxyProperties;
   private SpringAddonsRestProperties restProperties;
@@ -26,11 +29,20 @@ public class RestClientFactoryBean implements FactoryBean<RestClient> {
   private Optional<ClientHttpRequestFactory> clientHttpRequestFactory;
   private RestClient.Builder restClientBuilder;
   private Optional<RestClientSsl> ssl;
+  private @Nullable ApplicationContext applicationContext;
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    this.applicationContext = applicationContext;
+  }
 
   @Override
   @Nullable
   public RestClient getObject() throws Exception {
     final var builderFactoryBean = new RestClientBuilderFactoryBean();
+    if (applicationContext != null) {
+      builderFactoryBean.setApplicationContext(applicationContext);
+    }
     builderFactoryBean.setClientId(clientId);
     builderFactoryBean.setSystemProxyProperties(systemProxyProperties);
     builderFactoryBean.setRestProperties(restProperties);

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/SpringAddonsClientHttpRequestFactory.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/SpringAddonsClientHttpRequestFactory.java
@@ -15,10 +15,12 @@ import java.time.Duration;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpRequest;
@@ -51,27 +53,40 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
 
   public SpringAddonsClientHttpRequestFactory(SystemProxyProperties systemProperties,
       ClientHttpRequestFactoryProperties addonsProperties) {
-    this(systemProperties, addonsProperties, Optional.empty());
+    this(systemProperties, addonsProperties, Optional.empty(), Optional.empty());
+  }
+
+  public SpringAddonsClientHttpRequestFactory(SystemProxyProperties systemProperties,
+      ClientHttpRequestFactoryProperties addonsProperties, Optional<Executor> executor) {
+    this(systemProperties, addonsProperties, executor, Optional.empty());
   }
 
   /**
    * @param executor the {@link Executor} to set on the underlying client when use-virtual-threads is
    *        enabled (typically the application task executor resolved from the context). Honored by
    *        the JDK and Jetty implementations.
+   * @param httpClientBuilderConsumer optional {@link Consumer} bean applied to the
+   *        implementation-specific client builder just before the request factory is built. The
+   *        consumed type depends on the configured implementation:
+   *        {@code java.net.http.HttpClient.Builder} (JDK),
+   *        {@code org.apache.hc.client5.http.impl.classic.HttpClientBuilder} (HTTP_COMPONENTS) or
+   *        {@code org.eclipse.jetty.client.HttpClient} (JETTY).
    */
   public SpringAddonsClientHttpRequestFactory(SystemProxyProperties systemProperties,
-      ClientHttpRequestFactoryProperties addonsProperties, Optional<Executor> executor) {
+      ClientHttpRequestFactoryProperties addonsProperties, Optional<Executor> executor,
+      Optional<? extends Consumer<?>> httpClientBuilderConsumer) {
     final var proxySupport = new ProxySupport(systemProperties, addonsProperties.getProxy());
 
     this.nonProxyHostsPattern = proxySupport.isEnabled()
         ? Optional.ofNullable(proxySupport.getNoProxy()).map(Pattern::compile)
         : Optional.empty();
 
-    this.noProxyDelegate = clientHttpRequestFactory(null, addonsProperties, executor);
+    this.noProxyDelegate =
+        clientHttpRequestFactory(null, addonsProperties, executor, httpClientBuilderConsumer);
 
     if (proxySupport.isEnabled()) {
-      this.proxyDelegate =
-          new ProxyAwareClientHttpRequestFactory(proxySupport, addonsProperties, executor);
+      this.proxyDelegate = new ProxyAwareClientHttpRequestFactory(proxySupport, addonsProperties,
+          executor, httpClientBuilderConsumer);
     } else {
       this.proxyDelegate = this.noProxyDelegate;
     }
@@ -100,20 +115,25 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
     return httpClient;
   }
 
+  @SuppressWarnings("unchecked")
   private static ClientHttpRequestFactory clientHttpRequestFactory(ProxySupport proxySupport,
-      ClientHttpRequestFactoryProperties properties, Optional<Executor> executor) {
+      ClientHttpRequestFactoryProperties properties, Optional<Executor> executor,
+      Optional<? extends Consumer<?>> httpClientBuilderConsumer) {
     switch (properties.getClientHttpRequestFactoryImpl()) {
       case HTTP_COMPONENTS:
         try {
-          return HttpComponentsClientHttpRequestFactoryHelper.get(proxySupport, properties);
+          return HttpComponentsClientHttpRequestFactoryHelper.get(proxySupport, properties,
+              (Optional<Consumer<HttpClientBuilder>>) httpClientBuilderConsumer);
         } catch (KeyManagementException | NoSuchAlgorithmException | KeyStoreException e) {
           throw new RestMisconfigurationException(e);
         }
       case JETTY:
-        return JettyClientHttpRequestFactoryHelper.get(proxySupport, properties, executor);
+        return JettyClientHttpRequestFactoryHelper.get(proxySupport, properties, executor,
+            (Optional<Consumer<org.eclipse.jetty.client.HttpClient>>) httpClientBuilderConsumer);
       default:
         try {
-          return jdkClientHttpRequestFactory(proxySupport, properties, executor);
+          return jdkClientHttpRequestFactory(proxySupport, properties, executor,
+              (Optional<Consumer<HttpClient.Builder>>) httpClientBuilderConsumer);
         } catch (KeyManagementException | NoSuchAlgorithmException e) {
           throw new RestMisconfigurationException(e);
         }
@@ -121,7 +141,8 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
   }
 
   private static JdkClientHttpRequestFactory jdkClientHttpRequestFactory(ProxySupport proxySupport,
-      ClientHttpRequestFactoryProperties properties, Optional<Executor> executor)
+      ClientHttpRequestFactoryProperties properties, Optional<Executor> executor,
+      Optional<Consumer<HttpClient.Builder>> httpClientBuilderConsumer)
       throws NoSuchAlgorithmException, KeyManagementException {
     final var httpClientBuilder = httpClientBuilder(properties, executor);
     if (proxySupport != null && proxySupport.isEnabled()) {
@@ -150,6 +171,8 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
       httpClientBuilder.sslContext(sslContext);
     }
 
+    httpClientBuilderConsumer.ifPresent(consumer -> consumer.accept(httpClientBuilder));
+
     final var clientHttpRequestFactory = new JdkClientHttpRequestFactory(httpClientBuilder.build());
     properties.getReadTimeoutMillis().map(Duration::ofMillis)
         .ifPresent(clientHttpRequestFactory::setReadTimeout);
@@ -163,7 +186,8 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
     private final @Nullable String password;
 
     public ProxyAwareClientHttpRequestFactory(ProxySupport proxySupport,
-        ClientHttpRequestFactoryProperties properties, Optional<Executor> executor) {
+        ClientHttpRequestFactoryProperties properties, Optional<Executor> executor,
+        Optional<? extends Consumer<?>> httpClientBuilderConsumer) {
       this.username = proxySupport.getUsername();
       this.password = proxySupport.getPassword();
       final var httpClient = HttpClient.newBuilder();
@@ -172,7 +196,8 @@ public class SpringAddonsClientHttpRequestFactory implements ClientHttpRequestFa
       httpClient.proxy(ProxySelector.of(proxyAddress));
       properties.getConnectTimeoutMillis().map(Duration::ofMillis)
           .ifPresent(httpClient::connectTimeout);
-      this.delegate = clientHttpRequestFactory(proxySupport, properties, executor);
+      this.delegate =
+          clientHttpRequestFactory(proxySupport, properties, executor, httpClientBuilderConsumer);
     }
 
     @Override

--- a/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/HttpClientBuilderConsumerBeanTest.java
+++ b/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/HttpClientBuilderConsumerBeanTest.java
@@ -20,8 +20,7 @@ import org.springframework.web.client.RestClient;
  * bean is resolved from the application context and applied to the implementation-specific client
  * builder for each client-http-request-factory-impl.
  */
-@SpringBootTest(
-    classes = HttpClientBuilderConsumerEndToEndTest.ConsumersConfiguration.class,
+@SpringBootTest(classes = HttpClientBuilderConsumerBeanTest.ConsumersConfiguration.class,
     properties = {"spring.main.web-application-type=servlet",
         "spring.autoconfigure.exclude=org.springframework.boot.http.client.autoconfigure.imperative.ImperativeHttpClientAutoConfiguration",
         "com.c4-soft.springaddons.rest.client.foo-client.base-url=http://localhost:1",
@@ -34,7 +33,7 @@ import org.springframework.web.client.RestClient;
         "com.c4-soft.springaddons.rest.client.hc-e2e-client.base-url=http://localhost:1",
         "com.c4-soft.springaddons.rest.client.hc-e2e-client.http.client-http-request-factory-impl=http-components",
         "com.c4-soft.springaddons.rest.client.hc-e2e-client.http.http-client-builder-consumer-bean=httpComponentsHttpClientBuilderConsumer"})
-class HttpClientBuilderConsumerEndToEndTest {
+class HttpClientBuilderConsumerBeanTest {
 
   @Autowired
   private RestClient jdkE2eClient;

--- a/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/HttpClientBuilderConsumerEndToEndTest.java
+++ b/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/HttpClientBuilderConsumerEndToEndTest.java
@@ -1,0 +1,103 @@
+package com.c4_soft.springaddons.rest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+/**
+ * End-to-end check of the http-client-builder-consumer-bean property: the named {@link Consumer}
+ * bean is resolved from the application context and applied to the implementation-specific client
+ * builder for each client-http-request-factory-impl.
+ */
+@SpringBootTest(
+    classes = HttpClientBuilderConsumerEndToEndTest.ConsumersConfiguration.class,
+    properties = {"spring.main.web-application-type=servlet",
+        "spring.autoconfigure.exclude=org.springframework.boot.http.client.autoconfigure.imperative.ImperativeHttpClientAutoConfiguration",
+        "com.c4-soft.springaddons.rest.client.foo-client.base-url=http://localhost:1",
+        "com.c4-soft.springaddons.rest.client.bar-client.base-url=http://localhost:1",
+        "com.c4-soft.springaddons.rest.client.jdk-e2e-client.base-url=http://localhost:1",
+        "com.c4-soft.springaddons.rest.client.jdk-e2e-client.http.http-client-builder-consumer-bean=jdkHttpClientBuilderConsumer",
+        "com.c4-soft.springaddons.rest.client.jetty-e2e-client.base-url=http://localhost:1",
+        "com.c4-soft.springaddons.rest.client.jetty-e2e-client.http.client-http-request-factory-impl=jetty",
+        "com.c4-soft.springaddons.rest.client.jetty-e2e-client.http.http-client-builder-consumer-bean=jettyHttpClientBuilderConsumer",
+        "com.c4-soft.springaddons.rest.client.hc-e2e-client.base-url=http://localhost:1",
+        "com.c4-soft.springaddons.rest.client.hc-e2e-client.http.client-http-request-factory-impl=http-components",
+        "com.c4-soft.springaddons.rest.client.hc-e2e-client.http.http-client-builder-consumer-bean=httpComponentsHttpClientBuilderConsumer"})
+class HttpClientBuilderConsumerEndToEndTest {
+
+  @Autowired
+  private RestClient jdkE2eClient;
+
+  @Autowired
+  private RestClient jettyE2eClient;
+
+  @Autowired
+  private RestClient hcE2eClient;
+
+  @Autowired
+  private RestClient fooClient;
+
+  @Test
+  void givenConsumerBeanNames_whenRestClientsAreCreated_thenEachConsumerIsAppliedToItsBuilder() {
+    assertNotNull(jdkE2eClient);
+    assertNotNull(jettyE2eClient);
+    assertNotNull(hcE2eClient);
+
+    assertFalse(ConsumersConfiguration.jdkSeen.isEmpty());
+    assertInstanceOf(java.net.http.HttpClient.Builder.class, ConsumersConfiguration.jdkSeen.get(0));
+
+    assertFalse(ConsumersConfiguration.jettySeen.isEmpty());
+    assertInstanceOf(org.eclipse.jetty.client.HttpClient.class,
+        ConsumersConfiguration.jettySeen.get(0));
+
+    assertFalse(ConsumersConfiguration.hcSeen.isEmpty());
+    assertInstanceOf(org.apache.hc.client5.http.impl.classic.HttpClientBuilder.class,
+        ConsumersConfiguration.hcSeen.get(0));
+  }
+
+  @Test
+  void givenNoConsumerBeanName_whenRestClientIsCreated_thenNoConsumerIsApplied() {
+    assertNotNull(fooClient);
+    assertTrue(ConsumersConfiguration.fooSeen.isEmpty());
+  }
+
+  @Configuration
+  @EnableAutoConfiguration
+  static class ConsumersConfiguration {
+    static final List<Object> jdkSeen = new CopyOnWriteArrayList<>();
+    static final List<Object> jettySeen = new CopyOnWriteArrayList<>();
+    static final List<Object> hcSeen = new CopyOnWriteArrayList<>();
+    static final List<Object> fooSeen = new CopyOnWriteArrayList<>();
+
+    @Bean
+    Consumer<java.net.http.HttpClient.Builder> jdkHttpClientBuilderConsumer() {
+      return jdkSeen::add;
+    }
+
+    @Bean
+    Consumer<org.eclipse.jetty.client.HttpClient> jettyHttpClientBuilderConsumer() {
+      return jettySeen::add;
+    }
+
+    @Bean
+    Consumer<org.apache.hc.client5.http.impl.classic.HttpClientBuilder> httpComponentsHttpClientBuilderConsumer() {
+      return hcSeen::add;
+    }
+
+    @Bean
+    Consumer<Object> unusedConsumer() {
+      return fooSeen::add;
+    }
+  }
+}

--- a/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/SpringAddonsClientHttpRequestFactoryConsumerTest.java
+++ b/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/SpringAddonsClientHttpRequestFactoryConsumerTest.java
@@ -1,0 +1,52 @@
+package com.c4_soft.springaddons.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.ClientHttpRequest;
+import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties;
+import com.c4_soft.springaddons.rest.synchronised.SpringAddonsClientHttpRequestFactory;
+
+/**
+ * Verifies that the http-client-builder-consumer {@link Consumer} is applied to the underlying
+ * client builder by {@link SpringAddonsClientHttpRequestFactory} (JDK implementation).
+ */
+class SpringAddonsClientHttpRequestFactoryConsumerTest {
+
+  @Test
+  void givenJdkHttpClientBuilderConsumer_whenCreatingRequest_thenItIsAppliedToTheHttpClient()
+      throws Exception {
+    final var http = new ClientHttpRequestFactoryProperties();
+    final Consumer<HttpClient.Builder> consumer =
+        builder -> builder.version(HttpClient.Version.HTTP_1_1);
+
+    final var factory = new SpringAddonsClientHttpRequestFactory(new SystemProxyProperties(), http,
+        Optional.empty(), Optional.of(consumer));
+
+    assertEquals(HttpClient.Version.HTTP_1_1, jdkHttpClientOf(factory).version());
+  }
+
+  @Test
+  void givenNoHttpClientBuilderConsumer_whenCreatingRequest_thenTheJdkDefaultIsKept()
+      throws Exception {
+    final var http = new ClientHttpRequestFactoryProperties();
+
+    final var factory = new SpringAddonsClientHttpRequestFactory(new SystemProxyProperties(), http,
+        Optional.empty(), Optional.empty());
+
+    assertEquals(HttpClient.Version.HTTP_2, jdkHttpClientOf(factory).version());
+  }
+
+  private static HttpClient jdkHttpClientOf(SpringAddonsClientHttpRequestFactory factory)
+      throws Exception {
+    final ClientHttpRequest request =
+        factory.createRequest(URI.create("https://localhost/test"), HttpMethod.GET);
+    final var httpClientField = request.getClass().getDeclaredField("httpClient");
+    httpClientField.setAccessible(true);
+    return (HttpClient) httpClientField.get(request);
+  }
+}

--- a/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/SpringAddonsClientHttpRequestFactoryConsumerTest.java
+++ b/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/SpringAddonsClientHttpRequestFactoryConsumerTest.java
@@ -12,8 +12,9 @@ import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProper
 import com.c4_soft.springaddons.rest.synchronised.SpringAddonsClientHttpRequestFactory;
 
 /**
- * Verifies that the http-client-builder-consumer {@link Consumer} is applied to the underlying
- * client builder by {@link SpringAddonsClientHttpRequestFactory} (JDK implementation).
+ * Verifies that the {@link Consumer} referenced by the
+ * {@code http.http-client-builder-consumer-bean} property is applied to the underlying client
+ * builder by {@link SpringAddonsClientHttpRequestFactory} (JDK implementation).
  */
 class SpringAddonsClientHttpRequestFactoryConsumerTest {
 


### PR DESCRIPTION
Part of #298. Stacked on top of #299 — please merge #299 first; this PR will then be rebased onto master to leave only the customizer commit. (Until then it shows #299's commits too.)

Adds a per-client request factory customizer, for configuration that is not exposed as properties.

- New `HttpClientCustomizer<B>` functional interface — a single generic interface where `B` is the implementation-specific builder of the configured `client-http-request-factory-impl`: `java.net.http.HttpClient.Builder` (jdk), `org.apache.hc.client5.http.impl.classic.HttpClientBuilder` (http-components) or `org.eclipse.jetty.client.HttpClient` (jetty).
- New per-client `request-factory-customizer-bean` property naming the bean to apply.
- The bean is resolved from the `ApplicationContext` and applied to the underlying client builder just before the request factory is built, in each implementation's helper.

Example:
```yaml
com:
  c4-soft:
    springaddons:
      rest:
        client:
          machin-client:
            http:
              request-factory-customizer-bean: machinHttpClientCustomizer                                                                                                                                                                                                                                             
```
```java
@Bean
HttpClientCustomizer<HttpClient.Builder> machinHttpClientCustomizer() {                                                                                                                                                                                                                                               
  return builder -> builder.version(HttpClient.Version.HTTP_1_1);                                                                                                                                                                                                                                                     
}
```
README updated with a dedicated section; tests included.    