### PR TITLE
Honor declared per-client http properties over a context request factory

### DIFF
--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/SpringAddonsRestProperties.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/SpringAddonsRestProperties.java
@@ -245,8 +245,11 @@ public class SpringAddonsRestProperties {
       private Optional<Integer> readTimeoutMillis = Optional.empty();
 
       /**
-       * Which {@link ClientHttpRequestFactory} implementation to use if no bean is already
-       * configured by the application.
+       * Which {@link ClientHttpRequestFactory} implementation to use when the factory is built
+       * from these properties. Since Spring Boot 4,
+       * {@code ImperativeHttpClientAutoConfiguration} always contributes a
+       * {@link ClientHttpRequestFactory} bean; that bean is used only for clients which declare
+       * no property in this section, or which set prefer-context-factory to true.
        * <ul>
        * <li>HTTP_COMPONENTS requires org.apache.httpcomponents.client5:httpclient5 to be on the
        * class-path</li>
@@ -290,6 +293,19 @@ public class SpringAddonsRestProperties {
        * {@code org.eclipse.jetty.client.HttpClient} for JETTY.
        */
       private Optional<String> httpClientBuilderConsumerBean = Optional.empty();
+
+      /**
+       * If true, a {@link ClientHttpRequestFactory} bean from the application context takes
+       * precedence over the other properties in this section, which are then ignored.
+       * <p>
+       * False by default. Since Spring Boot 4, {@code ImperativeHttpClientAutoConfiguration}
+       * contributes a {@link ClientHttpRequestFactory} bean to any application which does not
+       * exclude it, so making the context bean win unconditionally would silently disable every
+       * property declared here. A client which declares no property in this section keeps using
+       * the context bean whatever this flag is set to.
+       * </p>
+       */
+      private boolean preferContextFactory = false;
 
       @Data
       public static class ProxyProperties {

--- a/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/RestClientBuilderFactoryBean.java
+++ b/spring-addons-starter-rest/src/main/java/com/c4_soft/springaddons/rest/synchronised/RestClientBuilderFactoryBean.java
@@ -30,8 +30,10 @@ import com.c4_soft.springaddons.rest.SpringAddonsRestProperties.RestClientProper
 import com.c4_soft.springaddons.rest.SystemProxyProperties;
 import lombok.Data;
 import lombok.experimental.FieldNameConstants;
+import lombok.extern.slf4j.Slf4j;
 
 @Data
+@Slf4j
 @FieldNameConstants
 public class RestClientBuilderFactoryBean
     implements FactoryBean<RestClient.Builder>, ApplicationContextAware {
@@ -87,6 +89,35 @@ public class RestClientBuilderFactoryBean
     return Optional.of(applicationContext.getBean(beanName, Consumer.class));
   }
 
+  /**
+   * The {@link ClientHttpRequestFactory} bean from the application context, but only when it does
+   * not silently discard properties the client declared: since Spring Boot 4 such a bean is
+   * auto-configured for every application, so a client which declares any of the
+   * {@code http.*} properties gets a factory built from them instead, unless it explicitly opts
+   * out with {@code http.prefer-context-factory}.
+   */
+  private Optional<ClientHttpRequestFactory> contextClientHttpRequestFactory(
+      SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties http) {
+    if (clientHttpRequestFactory.isEmpty() || !declaresRequestFactoryProperties(http)) {
+      return clientHttpRequestFactory;
+    }
+    if (http.isPreferContextFactory()) {
+      log.warn(
+          "REST client '{}' uses the ClientHttpRequestFactory bean from the application context, so its com.c4-soft.springaddons.rest.client.{}.http.* properties are ignored (prefer-context-factory is true).",
+          clientId, clientId);
+      return clientHttpRequestFactory;
+    }
+    return Optional.empty();
+  }
+
+  private static boolean declaresRequestFactoryProperties(
+      SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties http) {
+    final var defaults =
+        new SpringAddonsRestProperties.RestClientProperties.ClientHttpRequestFactoryProperties();
+    defaults.setPreferContextFactory(http.isPreferContextFactory());
+    return !defaults.equals(http);
+  }
+
   @Override
   public RestClient.Builder getObject() throws Exception {
     final var clientProps = Optional.ofNullable(restProperties.getClient().get(clientId))
@@ -95,10 +126,10 @@ public class RestClientBuilderFactoryBean
     final var builder = restClientBuilder.clone();
 
     // Handle HTTP or SOCK proxy and set timeouts
-    builder.requestFactory(clientHttpRequestFactory
-        .orElseGet(() -> new SpringAddonsClientHttpRequestFactory(systemProxyProperties,
-            clientProps.getHttp(), virtualThreadsExecutor(clientProps.getHttp()),
-            httpClientBuilderConsumer(clientProps.getHttp()))));
+    final var http = clientProps.getHttp();
+    builder.requestFactory(contextClientHttpRequestFactory(http)
+        .orElseGet(() -> new SpringAddonsClientHttpRequestFactory(systemProxyProperties, http,
+            virtualThreadsExecutor(http), httpClientBuilderConsumer(http))));
 
     clientProps.getBaseUrl().map(URL::toString).ifPresent(builder::baseUrl);
 

--- a/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/ContextFactoryPrecedenceTest.java
+++ b/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/ContextFactoryPrecedenceTest.java
@@ -1,0 +1,87 @@
+package com.c4_soft.springaddons.rest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.IOException;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.NestedExceptionUtils;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+/**
+ * A {@link ClientHttpRequestFactory} bean in the application context is used only for clients
+ * which declare no http property, or which explicitly opt in with prefer-context-factory. Any
+ * other client gets a factory built from the properties it declares.
+ */
+@SpringBootTest(classes = ContextFactoryPrecedenceTest.MarkerFactoryConfiguration.class,
+    properties = {"spring.main.web-application-type=servlet",
+        "com.c4-soft.springaddons.rest.client.declaring-client.base-url=http://localhost:1",
+        "com.c4-soft.springaddons.rest.client.declaring-client.http.read-timeout-millis=1234",
+        "com.c4-soft.springaddons.rest.client.silent-client.base-url=http://localhost:1",
+        "com.c4-soft.springaddons.rest.client.opting-in-client.base-url=http://localhost:1",
+        "com.c4-soft.springaddons.rest.client.opting-in-client.http.read-timeout-millis=1234",
+        "com.c4-soft.springaddons.rest.client.opting-in-client.http.prefer-context-factory=true"})
+class ContextFactoryPrecedenceTest {
+
+  @Autowired
+  private RestClient declaringClient;
+
+  @Autowired
+  private RestClient silentClient;
+
+  @Autowired
+  private RestClient optingInClient;
+
+  @Test
+  void givenClientDeclaresHttpProperties_whenClientIsCreated_thenContextFactoryIsNotUsed() {
+    assertFalse(usesContextFactory(declaringClient));
+  }
+
+  @Test
+  void givenClientDeclaresNoHttpProperty_whenClientIsCreated_thenContextFactoryIsUsed() {
+    assertTrue(usesContextFactory(silentClient));
+  }
+
+  @Test
+  void givenClientPrefersContextFactory_whenClientIsCreated_thenContextFactoryIsUsed() {
+    assertTrue(usesContextFactory(optingInClient));
+  }
+
+  private static boolean usesContextFactory(RestClient client) {
+    try {
+      client.get().uri("/").retrieve().toBodilessEntity();
+      return false;
+    } catch (Exception e) {
+      final var cause = NestedExceptionUtils.getMostSpecificCause(e);
+      return MarkerClientHttpRequestFactory.MARKER.equals(cause.getMessage());
+    }
+  }
+
+  @Configuration
+  @EnableAutoConfiguration
+  static class MarkerFactoryConfiguration {
+
+    @Bean
+    ClientHttpRequestFactory markerClientHttpRequestFactory() {
+      return new MarkerClientHttpRequestFactory();
+    }
+  }
+
+  static class MarkerClientHttpRequestFactory implements ClientHttpRequestFactory {
+
+    static final String MARKER = "context ClientHttpRequestFactory bean was used";
+
+    @Override
+    public ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod) throws IOException {
+      throw new IOException(MARKER);
+    }
+  }
+}

--- a/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/HttpClientBuilderConsumerBeanTest.java
+++ b/spring-addons-starter-rest/src/test/java/com/c4_soft/springaddons/rest/HttpClientBuilderConsumerBeanTest.java
@@ -22,7 +22,6 @@ import org.springframework.web.client.RestClient;
  */
 @SpringBootTest(classes = HttpClientBuilderConsumerBeanTest.ConsumersConfiguration.class,
     properties = {"spring.main.web-application-type=servlet",
-        "spring.autoconfigure.exclude=org.springframework.boot.http.client.autoconfigure.imperative.ImperativeHttpClientAutoConfiguration",
         "com.c4-soft.springaddons.rest.client.foo-client.base-url=http://localhost:1",
         "com.c4-soft.springaddons.rest.client.bar-client.base-url=http://localhost:1",
         "com.c4-soft.springaddons.rest.client.jdk-e2e-client.base-url=http://localhost:1",


### PR DESCRIPTION
Since Spring Boot 4, ImperativeHttpClientAutoConfiguration contributes a ClientHttpRequestFactory to every application that does not exclude it. RestClientBuilderFactoryBean injects any context factory by type and reads clientProps.getHttp() only in the orElseGet fallback, so on the 9.x line -- which is Boot 4 only -- that fallback never runs and the whole per-client http section is silently inert: the factory implementation, SSL validation, timeouts, proxy settings, and the http-protocol-version, use-virtual-threads and http-client-builder-consumer-bean properties added in 9.1.5.

The context factory is now used only for clients that declare no http property, or that opt in with the new http.prefer-context-factory flag; a client declaring anything under http gets a factory built from it. A WARN reports the case where a declared block is discarded, which was previously silent and hard to diagnose.

Applications that declare no http property are unaffected. Applications that declare one currently have it ignored, so no working configuration depends on the present outcome.

HttpClientBuilderConsumerBeanTest no longer needs to exclude Boot's ImperativeHttpClientAutoConfiguration: it was only there to work around this.